### PR TITLE
Moved GPU accessors to subImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ interface XRCubeLayer extends XRLayer {
 //
 
 dictionary XRLayerInit {
-  unsigned int pixelWidth;
-  unsigned int pixelHeight;
+  required unsigned int pixelWidth;
+  required unsigned int pixelHeight;
   boolean stereo = false;
   boolean depth = true;
   boolean stencil = false;

--- a/README.md
+++ b/README.md
@@ -191,17 +191,15 @@ function onXRFrame(time, xrFrame) {
 
 dictionary XRSubImage {
   XRViewport viewport;
-  unsigned long? imageIndex; // for texture array
-  boolean primary;
+  boolean primary; // ??
   WebGLTexture? colorTexture;
-  WebGLTexture? depthStencilTextur;
+  WebGLTexture? depthStencilTexture;
   WebGLFramebuffer? framebuffer;
 }
 
 interface XRLayer {
   readonly attribute unsigned long pixelWidth;
   readonly attribute unsigned long pixelHeight;
-  readonly attribute unsigned long arraySize;
   readonly attribute boolean ignoreDepthValues;
 
   boolean blendTextureSourceAlpha = false;
@@ -281,7 +279,7 @@ interface XRWebGL2GraphicsBinding {
   Promise<XREquirectLayer> requestEquirectLayer(XRLayerInit init);
   Promise<XRCubeLayer> requestCubeLayer(XRLayerInit init); // Note only available with WebGL 2
   
-  XRSubImage? getViewSubImage(XRLayer layer, XRView view);
+  XRSubImage? getViewSubImage(XRLayer layer);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ interface XRCubeLayer extends XRLayer {
 //
 
 dictionary XRLayerInit {
-  required unsigned int pixelWidth;
-  required unsigned int pixelHeight;
+  unsigned int pixelWidth;
+  unsigned int pixelHeight;
   boolean stereo = false;
   boolean depth = true;
   boolean stencil = false;

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ function onXRFrame(time, xrFrame) {
   xrSession.requestAnimationFrame(onXRFrame);
 
   for (let view in xrViewerPose.views) {
-    let subImage = layer.getViewSubImage(view)
+    let subImage = xrGfx.getViewSubImage(layer, view)
     gl.bindFramebuffer(gl.FRAMEBUFFER, subImage.frameBuffer);
     let viewport = subImage.viewport;
     gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
@@ -169,7 +169,7 @@ function onXRFrame(time, xrFrame) {
   xrSession.requestAnimationFrame(onXRFrame);
 
   for (let view in xrViewerPose.views) {
-    let subImage = quadLayer.getViewSubImage(view);
+    let subImage = xrGfx.getViewSubImage(quadLayer, view);
 
     if (subImage.primary) {
       gl.bindFramebuffer(gl.FRAMEBUFFER, subImage.framebuffer);
@@ -199,8 +199,6 @@ dictionary XRSubImage {
 }
 
 interface XRLayer {
-  XRSubImage? getViewSubImage(XRView view);
-
   readonly attribute unsigned long pixelWidth;
   readonly attribute unsigned long pixelHeight;
   readonly attribute unsigned long arraySize;
@@ -270,6 +268,8 @@ interface XRWebGLGraphicsBinding {
   Promise<XRQuadLayer> requestQuadLayer(XRLayerInit init);
   Promise<XRCylinderLayer> requestCylinderLayer(XRLayerInit init);
   Promise<XREquirectLayer> requestEquirectLayer(XRLayerInit init);
+  
+  XRSubImage? getViewSubImage(XRLayer layer, XRView view);
 }
 
 interface XRWebGL2GraphicsBinding {
@@ -280,6 +280,8 @@ interface XRWebGL2GraphicsBinding {
   Promise<XRCylinderLayer> requestCylinderLayer(XRLayerInit init);
   Promise<XREquirectLayer> requestEquirectLayer(XRLayerInit init);
   Promise<XRCubeLayer> requestCubeLayer(XRLayerInit init); // Note only available with WebGL 2
+  
+  XRSubImage? getViewSubImage(XRLayer layer, XRView view);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ function onXRFrame(time, xrFrame) {
 // Layer interface
 //
 
+dictionary XRSubImage {
+  XRViewport viewport;
+  unsigned long imageIndex;
+  boolean primary;
+}
+
 interface XRLayer {
   XRSubImage? getViewSubImage(XRView view);
 
@@ -197,12 +203,6 @@ interface XRLayer {
 
   boolean blendTextureSourceAlpha = false;
   boolean chromaticAberrationCorrection = false;
-}
-
-interface XRSubImage {
-  readonly attribute XRViewport viewport;
-  readonly attribute unsigned long imageIndex;
-  readonly attribute boolean primary;
 }
 
 //
@@ -245,7 +245,7 @@ interface XRCubeLayer extends XRLayer {
 // Graphics Bindings
 //
 
-dictionary XRWebGLLayerSourceInit {
+dictionary XRLayerInit {
   required unsigned int pixelWidth;
   required unsigned int pixelHeight;
   boolean stereo = false;
@@ -261,9 +261,9 @@ interface XRWebGLGraphicsBinding {
   double getNativeProjectionScaleFactor();
 
   Promise<XRProjectionLayer> requestProjectionLayer(XRWebGLLayerInit init); // Note different dictionary
-  Promise<XRQuadLayer> requestQuadLayer(XRWebGLLayerSourceInit init);
-  Promise<XRCylinderLayer> requestCylinderLayer(XRWebGLLayerSourceInit init);
-  Promise<XREquirectLayer> requestEquirectLayer(XRWebGLLayerSourceInit init);
+  Promise<XRQuadLayer> requestQuadLayer(XRLayerInit init);
+  Promise<XRCylinderLayer> requestCylinderLayer(XRLayerInit init);
+  Promise<XREquirectLayer> requestEquirectLayer(XRLayerInit init);
 
   WebGLFramebuffer? getCurrentFramebuffer(XRLayer layer);
 }
@@ -272,10 +272,10 @@ interface XRWebGL2GraphicsBinding {
   constructor(XRSession session, WebGL2RenderingContext context);
 
   Promise<XRProjectionLayer> requestProjectionLayer(XRWebGLLayerInit init);
-  Promise<XRQuadLayer> requestQuadLayer(XRWebGLLayerSourceInit init);
-  Promise<XRCylinderLayer> requestCylinderLayer(XRWebGLLayerSourceInit init);
-  Promise<XREquirectLayer> requestEquirectLayer(XRWebGLLayerSourceInit init);
-  Promise<XRCubeLayer> requestCubeLayer(XRWebGLLayerSourceInit init); // Note only available with WebGL 2
+  Promise<XRQuadLayer> requestQuadLayer(XRLayerInit init);
+  Promise<XRCylinderLayer> requestCylinderLayer(XRLayerInit init);
+  Promise<XREquirectLayer> requestEquirectLayer(XRLayerInit init);
+  Promise<XRCubeLayer> requestCubeLayer(XRLayerInit init); // Note only available with WebGL 2
 
   WebGLTexture? getCurrentColorTexture(XRLayer layer);
   WebGLTexture? getCurrentDepthStencilTexture(XRLayer layer);

--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ interface XRCubeLayer extends XRLayer {
 dictionary XRLayerInit {
   required unsigned int pixelWidth;
   required unsigned int pixelHeight;
-  boolean framebuffer = true; // should it be false?
   boolean stereo = false;
   boolean depth = true;
   boolean stencil = false;
@@ -263,8 +262,8 @@ dictionary XRLayerInit {
   boolean ignoreDepthValues = false;
 }
 
-interface XRWebGLGraphicsBinding {
-  constructor(XRSession session, WebGLRenderingContext context);
+interface XRWebGLTextureLayerFactory {
+  constructor(XRSession session, XRWebGLRenderingContext context);
 
   double getNativeProjectionScaleFactor();
 
@@ -273,12 +272,12 @@ interface XRWebGLGraphicsBinding {
   Promise<XRCylinderLayer> requestCylinderLayer(XRLayerInit init);
   Promise<XREquirectLayer> requestEquirectLayer(XRLayerInit init);
   
-  XRSubImage? getViewSubImage(XRLayer layer); // for mono layers
-  XRSubImage? getViewSubImage(XRLayer layer, XRView view); // for stereo layers
+  XRWebGLTextureSubImage? getViewSubImage(XRLayer layer); // for mono layers
+  XRWebGLTextureSubImage? getViewSubImage(XRLayer layer, XRView view); // for stereo layers
 }
 
-interface XRWebGL2GraphicsBinding {
-  constructor(XRSession session, WebGL2RenderingContext context);
+interface XRWebGLFramebufferLayerFactory {
+  constructor(XRSession session, XRWebGLRenderingContext context);
 
   Promise<XRProjectionLayer> requestProjectionLayer(XRWebGLLayerInit init);
   Promise<XRQuadLayer> requestQuadLayer(XRLayerInit init);
@@ -286,8 +285,8 @@ interface XRWebGL2GraphicsBinding {
   Promise<XREquirectLayer> requestEquirectLayer(XRLayerInit init);
   Promise<XRCubeLayer> requestCubeLayer(XRLayerInit init); // Note only available with WebGL 2
   
-  XRSubImage? getViewSubImage(XRLayer layer); // for mono layers and stereo + texture array
-  XRSubImage? getViewSubImage(XRLayer layer, XRView view); // for stereo layers (only framebuffer?)
+  XRWebGLFramebufferSubImage? getViewSubImage(XRLayer layer); // for mono layers
+  XRWebGLFramebufferSubImage? getViewSubImage(XRLayer layer, XRView view); // for stereo layers
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ function onXRFrame(time, xrFrame) {
 // Layer interface
 //
 
-dictionary XRSubImage {
+interface XRSubImage {
   XRViewport viewport;
   boolean primary; // ??
   WebGLTexture? colorTexture;

--- a/README.md
+++ b/README.md
@@ -190,11 +190,17 @@ function onXRFrame(time, xrFrame) {
 //
 
 interface XRSubImage {
-  XRViewport viewport;
-  boolean primary; // ??
-  WebGLTexture? colorTexture;
-  WebGLTexture? depthStencilTexture;
-  WebGLFramebuffer? framebuffer;
+  readonly attribute XRViewport viewport;
+}
+
+interface XRWebGLFramebufferSubImage : XRSubImage {
+  readonly attribute WebGLFramebuffer framebuffer;
+}
+
+interface XRWebGLTextureSubImage : XRSubImage {
+  readonly attribute unsigned long imageIndex;
+  readonly attribute WebGLTexture colorTexture;
+  readonly attribute WebGLTexture depthTexture;
 }
 
 interface XRLayer {
@@ -267,7 +273,8 @@ interface XRWebGLGraphicsBinding {
   Promise<XRCylinderLayer> requestCylinderLayer(XRLayerInit init);
   Promise<XREquirectLayer> requestEquirectLayer(XRLayerInit init);
   
-  XRSubImage? getViewSubImage(XRLayer layer, XRView view);
+  XRSubImage? getViewSubImage(XRLayer layer); // for mono layers
+  XRSubImage? getViewSubImage(XRLayer layer, XRView view); // for stereo layers
 }
 
 interface XRWebGL2GraphicsBinding {
@@ -279,7 +286,8 @@ interface XRWebGL2GraphicsBinding {
   Promise<XREquirectLayer> requestEquirectLayer(XRLayerInit init);
   Promise<XRCubeLayer> requestCubeLayer(XRLayerInit init); // Note only available with WebGL 2
   
-  XRSubImage? getViewSubImage(XRLayer layer);
+  XRSubImage? getViewSubImage(XRLayer layer); // for mono layers and stereo + texture array
+  XRSubImage? getViewSubImage(XRLayer layer, XRView view); // for stereo layers (only framebuffer?)
 }
 ```
 


### PR DESCRIPTION
It feels a bit cleaner to move the WebGL buffers to subImage.
subImage tells you what texture and region of texture to use so why not put it all in 1 location