### PR TITLE
Removed the concept of the framebuffer layer factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ For some non-projection layers, such as a mono `XRQuadLayer` being shown on a st
 ```js
 // Render Loop for a projection layer with a WebGL framebuffer source.
 const glLayerFactory = new XRWebGLLayerFactory(xrSession, gl);
-const quadLayer = xrGfx.requestQuadLayer(gl.TEXTURE_2D, { pixelWidth: 512, pixelHeight: 512, stereo: false });
+const quadLayer = glLayerFactory.requestQuadLayer(gl.TEXTURE_2D, {
+  pixelWidth: 512, pixelHeight: 512, stereo: false
+});
 // Position 2 meters away from the origin with a width and height of 1.5 meters
 quadLayer.referenceSpace = xrReferenceSpace;
 quadLayer.transform = new XRRigidTransform({z: -2});
@@ -215,7 +217,7 @@ function onXRFrame(time, xrFrame) {
   xrSession.requestAnimationFrame(onXRFrame);
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-  let subImage = xrGfx.getSubImage(quadLayer);
+  let subImage = glLayerFactory.getSubImage(quadLayer);
   gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
     subImage.colorTexture, 0);
   let viewport = subImage.viewport;


### PR DESCRIPTION
/fixes #17

Simplifies the layers by leaving use of opaque framebuffers exclusively to the `XRWebGLLayer`, which is still treated as a first-class layer type here and as the only way to get antialiasing in WebGL 1.0. All new layer types use `WebGLTexture`s, which may be requested as `TEXTURE_2D` or `TEXTURE_2D_ARRAY` as the developer needs.