### PR TITLE
Remove optional from layers attribute

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -1392,7 +1392,7 @@ instances of {{XRLayer}}.
 
 <pre class="idl">
 [SecureContext, Exposed=Window] partial interface XRRenderState {
-  [SameObject] readonly attribute FrozenArray&lt;XRLayer&gt;? layers;
+  [SameObject] readonly attribute FrozenArray&lt;XRLayer&gt; layers;
 };
 </pre>
 


### PR DESCRIPTION
the layers array will always be populated because projection layers are supported by default