### PR TITLE
removed w3c.json since this repository is not yet moved to WG from CG

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,0 @@
- {
-    "group":      [109735]
-,   "contacts":   ["cabanier"]
-,   "repo-type":  "rec-track"
-}


### PR DESCRIPTION
@dontcallmedom , do we need to have w3c.json with not rec-track repo-type? (sorry, just forgot and/or not following direction...)