### PR TITLE
Ensure non-projection layers can have at most 2 slots + added Eye parameter to getSubImageView

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -250,6 +250,7 @@ The {{XRLayerLayout}} enum defines the layout of the layer.
 enum XRLayerLayout {
   "default",
   "mono",
+  "stereo",
   "stereo-left-right",
   "stereo-top-bottom"
 };
@@ -257,14 +258,16 @@ enum XRLayerLayout {
 
  - A layout of <dfn enum-value for="XRLayerLayout">default</dfn> indicates that the layer can accomodate all the views of session’s [=list of views=].
  - A layout of <dfn enum-value for="XRLayerLayout">mono</dfn> indicates that the layer is mono.
+ - A layout of <dfn enum-value for="XRLayerLayout">stereo</dfn> indicates that the layer is stereo.
  - A layout of <dfn enum-value for="XRLayerLayout">stereo-left-right</dfn> indicates that the layer is divided left to right.
  - A layout of <dfn enum-value for="XRLayerLayout">stereo-top-bottom</dfn> indicates that the layer is divided top to bottom.
 
-NOTE: If an {{XRCompositionLayer}} is created with an {{XRLayerLayout/"default"}} layout, it is highly recommended that it is allocated with an {{XRTextureType/"texture-array"}} texture type.
+NOTE: If an {{XRCompositionLayer}} is created with an {{XRLayerLayout/"default"}} or {{XRLayerLayout/"stereo"}} layout, it is highly recommended
+that it is allocated with an {{XRTextureType/"texture-array"}} texture type.
 
 Note: The {{XRLayerLayout/"stereo-left-right"}} and {{XRLayerLayout/"stereo-top-bottom"}} layouts are designed to minimize draw
 calls for content that is already in stereo (for example stereo videos or images). Experiences that don't require such assets types
-should use the {{XRLayerLayout/"default"}} layout.
+should use the {{XRLayerLayout/"default"}} or {{XRLayerLayout/"stereo"}} layout.
 
 XRCompositionLayer {#xrcompositionlayertype}
 --------------
@@ -859,8 +862,8 @@ interface XRWebGLBinding {
                                       optional XREquirectLayerInit init);
   XRCubeLayer createCubeLayer(optional XRCubeLayerInit init);
 
-  XRWebGLSubImage getSubImage(XRCompositionLayer layer, XRFrame frame);
-  XRWebGLSubImage getViewSubImage(XRCompositionLayer layer, XRView view);
+  XRWebGLSubImage getSubImage(XRCompositionLayer layer, XRFrame frame, optional XREye eye = "none");
+  XRWebGLSubImage getViewSubImage(XRProjectionLayer layer, XRView view);
 };
 </pre>
 
@@ -907,10 +910,12 @@ To <dfn>determine the layout attribute</dfn> using an {{XRTextureType}} |texture
   1. If |textureType| is {{"texture-array"}} and not all of the session’s [=view|views=] in the [=list of views=] have the same [=recommended WebGL texture resolution=], throw an {{NotSupportedError}} and abort these steps.
   1. If |layout| is {{XRLayerLayout/"mono"}}, return |layout| and abort these steps.
   1. If |layout| is {{XRLayerLayout/"default"}}, run the following steps:
+    1. If the size of [=list of views=] is <code>1</code>, return {{XRLayerLayout/"mono"}} and abort these steps.
     1. If |textureType| is {{"texture-array"}}, return |layout| and abort these steps.
+  1. If |layout| is {{XRLayerLayout/"default"}} or {{XRLayerLayout/"stereo"}}, run the following steps:
     1. If the user agent prefers {{XRLayerLayout/"stereo-left-right"}} layout, return {{XRLayerLayout/"stereo-left-right"}} and abort these steps.
     1. If the user agent prefers {{XRLayerLayout/"stereo-top-bottom"}} layout, return {{XRLayerLayout/"stereo-top-bottom"}} and abort these steps.
-  1. If |textureType| is {{"texture-array"}}, throw {{TypeError}} and abort these steps.
+  1. If |textureType| is {{"texture-array"}} and |layout| is {{XRLayerLayout/"stereo-left-right"}} or {{XRLayerLayout/"stereo-top-bottom"}}, throw {{TypeError}} and abort these steps.
   1. return |layout|.
 
 </div>
@@ -996,7 +1001,6 @@ To <dfn>allocate depth textures for projection layers</dfn> using an {{XRProject
 To <dfn>allocate color textures</dfn> using an {{XRCompositionLayer}} |layer|, an {{XRTextureType}} |textureType| and an {{XRLayerInit}} |init|, the user agent MUST run the following steps:
   1. let |array| be a [=new=] array in the [=relevant realm=] of |context|.
   1. let |context| be |layer|'s [=XRCompositionLayer/context=].
-  1. let |session| be |layer|'s [=XRCompositionLayer/session=].
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"mono"}}:
         <dl class="switch">
         <dt> If |textureType| is {{"texture-array"}}:
@@ -1004,14 +1008,13 @@ To <dfn>allocate color textures</dfn> using an {{XRCompositionLayer}} |layer|, a
         <dt> Otherwise
           <dd> Initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
         <dl>
-  1. let |numViews| be the number of the |session|'s [=list of views=].
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"default"}}:
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"stereo"}}:
         <dl class="switch">
         <dt> If |textureType| is {{"texture-array"}}:
-          <dd> Initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with |numViews| layers using |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+          <dd> Initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with 2 layers using |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
           <dd> Return |array| and abort these steps.
         <dt> Otherwise
-          <dd> Initialize |array| with |numViews| [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context| and |init|'s {{XRProjectionLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+          <dd> Initialize |array| with 2 [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context| and |init|'s {{XRProjectionLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
           <dd> Return |array| and abort these steps.
         </dl>
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context| and |init|'s {{XRLayerInit/alpha}}, double of {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
@@ -1025,24 +1028,23 @@ To <dfn>allocate color textures</dfn> using an {{XRCompositionLayer}} |layer|, a
 To <dfn>allocate depth textures</dfn> using an {{XRCompositionLayer}} |layer|, an {{XRTextureType}} |textureType| and an {{XRLayerInit}} |init|, the user agent MUST run the following steps:
   1. let |array| be a [=new=] array in the [=relevant realm=] of |context|.
   1. let |context| be |layer|'s [=XRCompositionLayer/context=].
-  1. let |session| be |layer|'s [=XRCompositionLayer/session=].
   1. If |init|'s {{XRLayerInit/depth}} and {{XRLayerInit/stencil}} are not set, return |array| and abort these steps.
   1. let |depthsupport| be true if |context| is a {{WebGL2RenderingContext}} or the {{WEBGL_depth_texture}} extension is enabled in |context|.
   1. If |init|'s {{XRLayerInit/depth}} or {{XRLayerInit/stencil}} are set and |depthsupport| is false, throw {{TypeError}} and abort these steps.
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"mono"}}:
         <dl class="switch">
         <dt> If |textureType| is {{"texture-array"}}:
-        <dd> Initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with 1 internal texture using |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+          <dd> Initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with 1 internal texture using |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
         <dt> Otherwise
-        <dd> Initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
-  1. let |numViews| be the number of the |session|'s [=list of views=].
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"default"}}:
+          <dd> Initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+        </dl>
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"stereo"}}:
         <dl class="switch">
         <dt> If |textureType| is {{"texture-array"}}:
-        <dd> Initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with |numViews| layers using |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+         <dd> Initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with 2 layers using |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
         <dd> Return |array| and abort these steps.
         <dt> Otherwise
-        <dd> Initialize |array| with |numViews| [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+          <dd> Initialize |array| with 2 [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
         <dd> Return |array| and abort these steps.
         </dl>
   1. If |layer|'s {{XRCompositionLayer/layout}}  is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context| and |init|'s {{XRLayerInit/stencil}}, double of {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
@@ -1095,6 +1097,7 @@ When this method is invoked, the user agent MUST run the following steps:
   1. Let |context| be [=this=] [=XRWebGLBinding/context=].
   1. If |session|'s [=ended=] value is <code>true</code>, throw {{InvalidStateError}} and abort these steps.
   1. If |context| is lost, throw {{InvalidStateError}} and abort these steps.
+  1. If |layout| is {{XRLayerLayout/"default"}}, throw {{TypeError}} and abort these steps.
   1. Let |layer| be a [=new=] {{XRQuadLayer}} in the [=relevant realm=] of [=this=].
   1. Run [=intialize a composition layer=] on |layer| with |session| and |context|.
   1. Run [=initialize a quad layer=] with |layer| and |init|.
@@ -1119,6 +1122,7 @@ When this method is invoked, the user agent MUST run the following steps:
   1. Let |context| be [=this=] [=XRWebGLBinding/context=].
   1. If |session|'s [=ended=] value is <code>true</code>, throw {{InvalidStateError}} and abort these steps.
   1. If |context| is lost, throw {{InvalidStateError}} and abort these steps.
+  1. If |layout| is {{XRLayerLayout/"default"}}, throw {{TypeError}} and abort these steps.
   1. Let |layer| be a [=new=] {{XRCylinderLayer}} in the [=relevant realm=] of [=this=].
   1. Run [=intialize a composition layer=] on |layer| with |session| and |context|.
   1. Run [=initialize a cylinder layer=] with |layer| and |init|.
@@ -1143,6 +1147,7 @@ When this method is invoked, the user agent MUST run the following steps:
   1. Let |context| be [=this=] [=XRWebGLBinding/context=].
   1. If |session|'s [=ended=] value is <code>true</code>, throw {{InvalidStateError}} and abort these steps.
   1. If |context| is lost, throw {{InvalidStateError}} and abort these steps.
+  1. If |layout| is {{XRLayerLayout/"default"}}, throw {{TypeError}} and abort these steps.
   1. If |init|'s {{XRLayerInit/space}} is not an instance of type {{XRReferenceSpace}}, throw {{TypeError}} and abort these steps.
   1. If |init|'s {{XRLayerInit/space}} has a [=XRReferenceSpace/type=] of {{XRReferenceSpaceType/"viewer"}}, throw {{TypeError}} and abort these steps.
   1. Let |layer| be a [=new=] {{XREquirectLayer}} in the [=relevant realm=] of [=this=].
@@ -1170,6 +1175,7 @@ When this method is invoked, the user agent MUST run the following steps:
   1. If |session|'s [=ended=] value is <code>true</code>, throw {{InvalidStateError}} and abort these steps.
   1. If |context| is not a {{WebGL2RenderingContext}} context, throw {{InvalidStateError}} and abort these steps.
   1. If |context| is lost, throw {{InvalidStateError}} and abort these steps.
+  1. If |layout| is {{XRLayerLayout/"default"}}, throw {{TypeError}} and abort these steps.
   1. If |init|'s {{XRLayerInit/space}} is not an instance of type {{XRReferenceSpace}}, throw {{TypeError}} and abort these steps.
   1. If |init|'s {{XRLayerInit/space}} has a [=XRReferenceSpace/type=] of {{XRReferenceSpaceType/"viewer"}}, throw {{TypeError}} and abort these steps.
   1. Let |layer| be a [=new=] {{XRCubeLayer}} in the [=relevant realm=] of [=this=].
@@ -1232,28 +1238,48 @@ To <dfn>validate the state of the XRWebGLSubImage creation function</dfn> of an 
 </div>
 
 <div class="algorithm" data-algorithm="getSubImageAlgo">
-The <dfn method for="XRWebGLBinding">getSubImage(XRCompositionLayer |layer|, XRFrame |frame|)</dfn> method creates a new {{XRWebGLSubImage}}.
+The <dfn method for="XRWebGLBinding">getSubImage(XRCompositionLayer |layer|, XRFrame |frame|, optional XREye |eye| = {{XREye/"none"}})</dfn> method creates a new {{XRWebGLSubImage}}.
 
 When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the following steps:
 
   1. Initialize |subimage| as follows:
     <dl class="switch">
-      <dt> If {{XRWebGLBinding/getSubImage()}} was called previously with the same |binding| and |layer|, the user agent MAY:
+      <dt> If {{XRWebGLBinding/getSubImage()}} was called previously with the same |binding|, |layer| and |eye|, the user agent MAY:
         <dd> Let |subimage| be the same {{XRWebGLSubImage}} object as returned by an earlier call with the same arguments.
       <dt> Otherwise
         <dd> Let |subimage| be a [=new=] {{XRWebGLSubImage}} in the [=relevant realm=] of [=this=].
     </dl>
-  1. If |layer|'s {{XRCompositionLayer/layout}} attribute is {{XRLayerLayout/"default"}}, throw an {{TypeError}} and abort these steps.
+  1. If |layer|'s {{XRCompositionLayer/layout}} attribute is {{XRLayerLayout/"default"}}, throw a {{TypeError}} and abort these steps.
+  1. Let |index| be <code>0</code>.
+  1. If |layer|'s {{XRCompositionLayer/layout}} attribute is {{XRLayerLayout/"stereo"}}:
+    1. If |eye| is {{XREye/"none"}}, throw a {{TypeError}} and abort these steps.
+    1. If |eye| is {{XREye/"right"}}, set |index| to <code>1</code>.
   1. If [=validate the state of the XRWebGLSubImage creation function=] with |layer| and |frame| is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
-  1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
-  1. If the layer has a depthStencilTexture, initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of the |layer|'s [=depthStencilTextures=] array.
-  1. [=Queue a task=] to set {{XRCompositionLayer/needsRedraw}} to <code>false</code>.
+  1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} as follows:
+    <dl class="switch">
+      <dt class="switch">If the |layer| was created with a textureType of {{"texture-array"}}
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
+      <dt> Otherwise
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
+      </dl>
+    </dl>
+  1. Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} as follows:
+    <dl class="switch">
+      <dt class="switch">If the |layer|'s [=depthStencilTextures=] is an empty array.
+        <dd> Continue to the next entry.
+      <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
+      <dt> Otherwise
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.
+      </dl>
+    </dl>  1. [=Queue a task=] to set {{XRCompositionLayer/needsRedraw}} to <code>false</code>.
   1. return |subimage|.
 
 </div>
 
 <div class="algorithm" data-algorithm="getViewSubImageAlgo">
-The <dfn method for="XRWebGLBinding">getViewSubImage(XRCompositionLayer |layer|, XRView |view|)</dfn> method creates a new {{XRWebGLSubImage}}.
+The <dfn method for="XRWebGLBinding">getViewSubImage(XRProjectionLayer |layer|, XRView |view|)</dfn> method creates a new {{XRWebGLSubImage}}.
 
 When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the following steps:
 
@@ -1265,25 +1291,27 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
         <dd> Let |subimage| be a [=new=] {{XRWebGLSubImage}} in the [=relevant realm=] of [=this=].
     </dl>
   1. let |frame| be |view|'s {{frame}}.
+  1. Let |session| be [=this=] [=XRWebGLBinding/session=].
   1. If [=validate the state of the XRWebGLSubImage creation function=] with |layer| and |frame| is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
-  1. let |index| be a [=new=] integer with the value <code>0</code> in the [=relevant realm=] of [=this=].
-  1. If |view|'s {{XRView/eye}} attribute is {{XREye/"right"}} and |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"default"}}, set |index| to <code>1</code>.
+  1. Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=].
   1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} as follows:
     <dl class="switch">
       <dt class="switch">If the |layer| was created with a textureType of {{"texture-array"}}
-      <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
-      <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
       <dt> Otherwise
-      <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
+      </dl>
     </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} as follows:
     <dl class="switch">
       <dt class="switch">If the |layer|'s [=depthStencilTextures=] is an empty array.
-      <dd> Continue to the next entry.
+        <dd> Continue to the next entry.
       <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
-      <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
       <dt> Otherwise
-      <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element of the |layer|'s [=depthStencilTextures=] array that corresponds to the |view|.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.
+      </dl>
     </dl>
   1. Set {{XRCompositionLayer/needsRedraw}} to <code>false</code>.
   1. return |subimage|

--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -259,10 +259,10 @@ enum XRLayerLayout {
  - A layout of <dfn enum-value for="XRLayerLayout">default</dfn> indicates that the layer can accomodate all the views of session’s [=list of views=].
  - A layout of <dfn enum-value for="XRLayerLayout">mono</dfn> indicates that the layer is mono.
  - A layout of <dfn enum-value for="XRLayerLayout">stereo</dfn> indicates that the layer is stereo.
- - A layout of <dfn enum-value for="XRLayerLayout">stereo-left-right</dfn> indicates that the layer is divided left to right.
- - A layout of <dfn enum-value for="XRLayerLayout">stereo-top-bottom</dfn> indicates that the layer is divided top to bottom.
+ - A layout of <dfn enum-value for="XRLayerLayout">stereo-left-right</dfn> indicates that the layer is stereo and divided left to right.
+ - A layout of <dfn enum-value for="XRLayerLayout">stereo-top-bottom</dfn> indicates that the layer is stereo and divided top to bottom.
 
-NOTE: If an {{XRCompositionLayer}} is created with an {{XRLayerLayout/"default"}} or {{XRLayerLayout/"stereo"}} layout, it is highly recommended
+NOTE: If an {{XRCompositionLayer}} is created with a {{XRLayerLayout/"default"}} or {{XRLayerLayout/"stereo"}} {{XRLayerLayout}}, it is highly recommended
 that it is allocated with an {{XRTextureType/"texture-array"}} texture type.
 
 Note: The {{XRLayerLayout/"stereo-left-right"}} and {{XRLayerLayout/"stereo-top-bottom"}} layouts are designed to minimize draw
@@ -915,7 +915,6 @@ To <dfn>determine the layout attribute</dfn> using an {{XRTextureType}} |texture
   1. If |layout| is {{XRLayerLayout/"default"}} or {{XRLayerLayout/"stereo"}}, run the following steps:
     1. If the user agent prefers {{XRLayerLayout/"stereo-left-right"}} layout, return {{XRLayerLayout/"stereo-left-right"}} and abort these steps.
     1. If the user agent prefers {{XRLayerLayout/"stereo-top-bottom"}} layout, return {{XRLayerLayout/"stereo-top-bottom"}} and abort these steps.
-  1. If |textureType| is {{"texture-array"}} and |layout| is {{XRLayerLayout/"stereo-left-right"}} or {{XRLayerLayout/"stereo-top-bottom"}}, throw {{TypeError}} and abort these steps.
   1. return |layout|.
 
 </div>
@@ -957,8 +956,8 @@ To <dfn>allocate color textures for projection layers</dfn> using an {{XRProject
           <dd> Return |array| and abort these steps.
         </dl>
   1. If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=], throw an {{NotSupportedError}} and abort these steps.
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context| , |alpha|, double of |width| and |height|.
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context| , |alpha|, |width| and double of |height|.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |alpha|, double of |width| and |height|.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |alpha|, |width| and double of |height|.
   1. return |array|.
 
 </div>
@@ -990,8 +989,8 @@ To <dfn>allocate depth textures for projection layers</dfn> using an {{XRProject
           <dd> Return |array| and abort these steps.
         </dl>
   1. If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=], throw an {{NotSupportedError}} and abort these steps.
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context| , |stencil|, double of |width| and |height|.
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context| , |stencil|, |width| and double of |height|.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |stencil|, double of |width| and |height|.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |stencil|, |width| and double of |height|.
   1. return |array|.
 
 </div>
@@ -1017,8 +1016,8 @@ To <dfn>allocate color textures</dfn> using an {{XRCompositionLayer}} |layer|, a
           <dd> Initialize |array| with 2 [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context| and |init|'s {{XRProjectionLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
           <dd> Return |array| and abort these steps.
         </dl>
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context| and |init|'s {{XRLayerInit/alpha}}, double of {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and double of {{XRLayerInit/viewPixelHeight}} values.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| and |init|'s {{XRLayerInit/alpha}}, double of {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and double of {{XRLayerInit/viewPixelHeight}} values.
   1. return |array|.
 
 </div>
@@ -1047,8 +1046,8 @@ To <dfn>allocate depth textures</dfn> using an {{XRCompositionLayer}} |layer|, a
           <dd> Initialize |array| with 2 [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
         <dd> Return |array| and abort these steps.
         </dl>
-  1. If |layer|'s {{XRCompositionLayer/layout}}  is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context| and |init|'s {{XRLayerInit/stencil}}, double of {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
-  1. If |layer|'s {{XRCompositionLayer/layout}}  is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and double of {{XRLayerInit/viewPixelHeight}} values.
+  1. If |layer|'s {{XRCompositionLayer/layout}}  is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| and |init|'s {{XRLayerInit/stencil}}, double of {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+  1. If |layer|'s {{XRCompositionLayer/layout}}  is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and double of {{XRLayerInit/viewPixelHeight}} values.
   1. return |array|.
 
 </div>
@@ -1175,7 +1174,6 @@ When this method is invoked, the user agent MUST run the following steps:
   1. If |session|'s [=ended=] value is <code>true</code>, throw {{InvalidStateError}} and abort these steps.
   1. If |context| is not a {{WebGL2RenderingContext}} context, throw {{InvalidStateError}} and abort these steps.
   1. If |context| is lost, throw {{InvalidStateError}} and abort these steps.
-  1. If |layout| is {{XRLayerLayout/"default"}}, throw {{TypeError}} and abort these steps.
   1. If |init|'s {{XRLayerInit/space}} is not an instance of type {{XRReferenceSpace}}, throw {{TypeError}} and abort these steps.
   1. If |init|'s {{XRLayerInit/space}} has a [=XRReferenceSpace/type=] of {{XRReferenceSpaceType/"viewer"}}, throw {{TypeError}} and abort these steps.
   1. Let |layer| be a [=new=] {{XRCubeLayer}} in the [=relevant realm=] of [=this=].
@@ -1191,15 +1189,14 @@ When this method is invoked, the user agent MUST run the following steps:
     </dl>
   1. let |layout| be |init|'s {{XRLayerInit/layout}}.
   1. Initialize |layer|'s {{XRCompositionLayer/needsRedraw}} to <code>true</code>.
-  1. If |layout| is {{XRLayerLayout/"stereo-left-right"}} or {{XRLayerLayout/"stereo-top-bottom"}}, throw {{TypeError}} and abort these steps.
+  1. If |layout| is {{XRLayerLayout/"default"}} or {{XRLayerLayout/"stereo-left-right"}} or {{XRLayerLayout/"stereo-top-bottom"}}, throw {{TypeError}} and abort these steps.
   1. Let |layer|'s [=colorTextures=] be a [=new=] array in the [=relevant realm=] of this {{XRCubeLayer}}.
-  1. let |numViews| be the number of |session|'s [=list of views=].
   1. Initialize |layer|'s [=colorTextures=] as follows, based on the value of |layout|:
     <dl class="switch">
       <dt> {{XRLayerLayout/"mono"}}:
         <dd> Initialize [=colorTextures=] with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of this {{XRCubeLayer}} created as a {{TEXTURE_CUBE_MAP}} texture with |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
       <dt> Otherwise
-        <dd> Initialize [=colorTextures=] with |numViews| [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of this {{XRCubeLayer}} created as a {{TEXTURE_CUBE_MAP}} texture with |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+        <dd> Initialize [=colorTextures=] with 2 [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of this {{XRCubeLayer}} created as a {{TEXTURE_CUBE_MAP}} texture with |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
     </dl>
   1. Let |layer|'s [=depthStencilTextures=] be a [=new=] array in the [=relevant realm=] of this {{XRCubeLayer}}.
   1. If |init|'s {{XRLayerInit/depth}} and {{XRLayerInit/stencil}} are set, initialize |layer|'s [=depthStencilTextures=] as follows:
@@ -1209,7 +1206,7 @@ When this method is invoked, the user agent MUST run the following steps:
       <dt> Else if |layout| is {{XRLayerLayout/"mono"}}:
         <dd> Initialize [=depthStencilTextures=] with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of this {{XRCubeLayer}} created as a {{TEXTURE_CUBE_MAP}} texture with |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
       <dt> Otherwise
-        <dd> Initialize [=depthStencilTextures=] with |numViews| [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of this {{XRCubeLayer}} created as a {{TEXTURE_CUBE_MAP}} texture with |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+        <dd> Initialize [=depthStencilTextures=] with 2 [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of this {{XRCubeLayer}} created as a {{TEXTURE_CUBE_MAP}} texture with |context| and |init|'s {{XRLayerInit/alpha}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
     </dl>
   1. Allocate and initialize resources compatible with |session|'s [=/XR device=], including GPU accessible memory buffers, as required to support the compositing of |layer|.
   1. If |layer|’s resources were unable to be created for any reason, throw an {{OperationError}} and abort these steps.
@@ -1249,6 +1246,7 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
       <dt> Otherwise
         <dd> Let |subimage| be a [=new=] {{XRWebGLSubImage}} in the [=relevant realm=] of [=this=].
     </dl>
+  1. If |layer|'s type is {{XRProjectionLayer}}, throw a {{TypeError}} and abort these steps.
   1. If |layer|'s {{XRCompositionLayer/layout}} attribute is {{XRLayerLayout/"default"}}, throw a {{TypeError}} and abort these steps.
   1. Let |index| be <code>0</code>.
   1. If |layer|'s {{XRCompositionLayer/layout}} attribute is {{XRLayerLayout/"stereo"}}:


### PR DESCRIPTION
This change ensures that non-projection layers are no longer tied to views. 
It also changes getSubImageView so it only works on projection layers
