### PR TITLE
Add support for secondary views and fix xr compositor language

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -47,6 +47,9 @@ spec: webxr-1;
     type: dfn; text: updateRenderState; for: XRSession
     type: dfn; text: session; for: XRWebGLLayer
     type: dfn; text: layers; for: XRRenderStateInit
+spec: webxr-ar-module-1;
+    type: dfn; text: first-person observer view
+    type: dfn; text: secondary-views
 spec: html;
     type: dfn; text: check the usability of the image argument
     type: dfn; text: request the xr permission
@@ -395,6 +398,10 @@ The <dfn attribute for="XRProjectionLayer">ignoreDepthValues</dfn> attribute, if
 [=XR Compositor=] MUST NOT make use of values in the depth buffer attachment when rendering. When the attribute
 is <code>false</code> it indicates that the content of the depth buffer attachment will be used by the
 [=XR Compositor=] and is expected to be representative of the scene rendered into the layer.
+
+Each {{XRProjectionLayer}} has an internal {{WebGLTexture}} <dfn for="XRProjectionLayer">first-person observer color texture</dfn>
+and an internal {{WebGLTexture}} <dfn for="XRProjectionLayer">first-person observer depth texture</dfn> that are used to render
+the [=first-person observer view=].
 
 XRQuadLayer {#xrquadlayertype}
 -----------
@@ -922,8 +929,8 @@ To <dfn>determine the layout attribute</dfn> using an {{XRTextureType}} |texture
 <div class="algorithm" data-algorithm="determine the maximum scalefactor">
 
 To <dfn>determine the maximum scalefactor</dfn> using an {{XRSession}} |session|, an {{XRWebGLRenderingContext}} |context| and an {{XRLayerLayout}} |layout|, the user agent MUST run the following steps:
-  1. Let |largest width| be the largest width of the [=recommended WebGL texture resolution=] from the |session|'s [=list of views=].
-  1. Let |largest height| be the largest height of the [=recommended WebGL texture resolution=] from the |session|'s [=list of views=].
+  1. Let |largest width| be the largest width of the [=recommended WebGL texture resolution=] from the |session|'s [=list of views=] excluding the [=first-person observer view=].
+  1. Let |largest height| be the largest height of the [=recommended WebGL texture resolution=] from the |session|'s [=list of views=] excluding the [=first-person observer view=].
   1. If |layout| is {{XRLayerLayout/"stereo-left-right"}} layout, multiply |largest width| by <code>2</code>.
   1. If |layout| is {{XRLayerLayout/"stereo-top-bottom"}} layout, multiply |largest height| by <code>2</code>.
   1. Let |largest view dimension| be the largest of |largest width| or |largest height|.
@@ -938,8 +945,8 @@ To <dfn>allocate color textures for projection layers</dfn> using an {{XRProject
   1. Let |array| be a [=new=] array in the [=relevant realm=] of |context|.
   1. Let |context| be |layer|'s [=XRCompositionLayer/context=].
   1. Let |session| be |layer|'s [=XRCompositionLayer/session=].
-  1. Let |numViews| be the number of the |session|'s [=list of views=].
-  1. Let |view| be the first entry in the |session|'s [=list of views=].
+  1. Let |numViews| be the number of the |session|'s [=list of views=] excluding the [=first-person observer view=].
+  1. Let |view| be the first entry in the |session|'s [=list of views=] that is not a [=first-person observer view=].
   1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
   1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"mono"}} or {{XRLayerLayout/"default"}}:
@@ -949,30 +956,31 @@ To <dfn>allocate color textures for projection layers</dfn> using an {{XRProject
           <dd> Return |array| and abort these steps.
         <dt> Otherwise
           <dd> For each |view| in the |session|'s [=list of views=]:
+            1. If |view| is a [=first-person observer view=], continue.
             1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
             1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
             1. let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context|, |alpha|, |width| and |height|.
             1. Append |texture| to |array|.
           <dd> Return |array| and abort these steps.
         </dl>
-  1. If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=], throw an {{NotSupportedError}} and abort these steps.
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |alpha|, double of |width| and |height|.
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |alpha|, |width| and double of |height|.
+  1. If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=] excluding the [=first-person observer view=], throw an {{NotSupportedError}} and abort these steps.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |alpha|, |numViews| multiplied by |width| and |height|.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |alpha|, |width| and |numViews| multiplied by |height|.
   1. return |array|.
 
 </div>
 
 <div class="algorithm" data-algorithm="allocate depth textures for projection layers">
 
-To <dfn>allocate depth textures for projection layers</dfn> using an {{XRProjectionLayer}} |layer|, an {{XRTextureType}} |textureType|, a boolean |stencil| and a float |scaleFactor|, the user agent MUST run the following steps:
+To <dfn>allocate depth textures for projection layers</dfn> using an {{XRProjectionLayer}} |layer|, an {{XRTextureType}} |textureType|, a boolean |depth|, a boolean |stencil| and a float |scaleFactor|, the user agent MUST run the following steps:
   1. let |array| be a [=new=] array in the [=relevant realm=] of |context|.
   1. let |context| be |layer|'s [=XRCompositionLayer/context=].
   1. let |session| be |layer|'s [=XRCompositionLayer/session=].
-  1. If |init|'s {{XRLayerInit/depth}} and {{XRLayerInit/stencil}} are not set, return |array| and abort these steps.
+  1. If |depth| and |stencil| are not set, return |array| and abort these steps.
   1. let |depthsupport| be true if |context| is a {{WebGL2RenderingContext}} or the {{WEBGL_depth_texture}} extension is enabled in |context|.
-  1. If |init|'s {{XRLayerInit/depth}} or {{XRLayerInit/stencil}} are set and |depthsupport| is false, throw {{TypeError}} and abort these steps.
-  1. let |numViews| be the number of the |session|'s [=list of views=].
-  1. Let |view| be the first entry in the |session|'s [=list of views=].
+  1. If |depth| or |stencil| are set and |depthsupport| is false, throw {{TypeError}} and abort these steps.
+  1. let |numViews| be the number of the |session|'s [=list of views=] excluding the [=first-person observer view=].
+  1. Let |view| be the first entry in the |session|'s [=list of views=] that is not a [=first-person observer view=].
   1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
   1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"mono"}} or {{XRLayerLayout/"default"}}:
@@ -982,18 +990,50 @@ To <dfn>allocate depth textures for projection layers</dfn> using an {{XRProject
           <dd> Return |array| and abort these steps.
         <dt> Otherwise
           <dd> For each |view| in the |session|'s [=list of views=]:
+            1. If |view| is a [=first-person observer view=], continue.
             1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
             1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
             1. let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context|, |stencil|, |width| and |height|.
             1. Append |texture| to |array|.
           <dd> Return |array| and abort these steps.
         </dl>
-  1. If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=], throw an {{NotSupportedError}} and abort these steps.
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |stencil|, double of |width| and |height|.
-  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |stencil|, |width| and double of |height|.
+  1. If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=] excluding the [=first-person observer view=], throw an {{NotSupportedError}} and abort these steps.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |stencil|, |numViews| multiplied by |width| and |height|.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |stencil|, |width| and |numViews| multiplied by |height|.
   1. return |array|.
 
 </div>
+
+<div class="algorithm" data-algorithm="allocate color texture for the first-person observer view">
+
+To <dfn>allocate the color texture for the first-person observer view</dfn> using an {{XRProjectionLayer}} |layer|, an {{XRTextureType}} |textureType|, a boolean |alpha| and a float |scaleFactor|, the user agent MUST run the following steps:
+  1. Let |context| be |layer|'s [=XRCompositionLayer/context=].
+  1. Let |session| be |layer|'s [=XRCompositionLayer/session=].
+  1. Let |view| be the [=first-person observer view=] from |session|'s [=list of views=].
+  1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
+  1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
+  1. If |textureType| is {{XRTextureType/"texture-array"}}, return a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with <code>1</code> layer using |context|, |alpha|, |width| and |height|.
+  1. Return a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context|, |alpha|, |width| and |height|.
+
+</div>
+
+<div class="algorithm" data-algorithm="allocate depth texture for the first-person observer view">
+
+To <dfn>allocate the depth texture for the first-person observer view</dfn> using an {{XRProjectionLayer}} |layer|, an {{XRTextureType}} |textureType|, a boolean |depth|, a boolean |stencil| and a float |scaleFactor|, the user agent MUST run the following steps:
+  1. Let |context| be |layer|'s [=XRCompositionLayer/context=].
+  1. Let |session| be |layer|'s [=XRCompositionLayer/session=].
+  1. If |depth| and |stencil| are not set, return <code>null</code> and abort these steps.
+  1. let |depthsupport| be true if |context| is a {{WebGL2RenderingContext}} or the {{WEBGL_depth_texture}} extension is enabled in |context|.
+  1. If |depth| or |stencil| are set and |depthsupport| is false, throw {{TypeError}} and abort these steps.
+  1. Let |view| be the [=first-person observer view=] from |session|'s [=list of views=].
+  1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
+  1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
+  1. If |textureType| is {{XRTextureType/"texture-array"}}, return a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with <code>1</code> layer using |context|, |stencil|, |width| and |height| and abort these steps.
+  1. Return a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context|, |stencil|, |width| and |height|.
+
+</div>
+
+ISSUE: the scaleFactor needs to be recalculated for the first-person observer view.
 
 <div class="algorithm" data-algorithm="allocate color textures">
 
@@ -1077,7 +1117,21 @@ When this method is invoked, the user agent MUST run the following steps:
   1. Initialize |layer|'s {{XRCompositionLayer/layout}} to |layout|.
   1. Initialize |layer|'s {{XRCompositionLayer/needsRedraw}} to <code>true</code>.
   1. let |layer|'s [=colorTextures=] be the result of [=allocate color textures for projection layers|allocating color textures for projection layers=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/alpha}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
-  1. let |layer|'s [=depthStencilTextures=] be the result of [=allocate depth textures for projection layers|allocating depth textures for projection layers=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/stencil}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
+  1. let |layer|'s [=depthStencilTextures=] be the result of [=allocate depth textures for projection layers|allocating depth textures for projection layers=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/depth}}, |init|'s {{XRProjectionLayerInit/stencil}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
+  1. Initialize the [=XRProjectionLayer/first-person observer color texture=] as follows:
+      <dl class="switch">
+        <dt> If the |session| was created with "[=feature descriptor/secondary-views=]" enabled
+          <dd> Let [=XRProjectionLayer/first-person observer color texture=] be the result of [=allocate the color texture for the first-person observer view=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/alpha}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
+        <dt> Otherwise
+          <dd> Let [=XRProjectionLayer/first-person observer color texture=] be <code>null</code>.
+      </dl>
+  1. Initialize the [=XRProjectionLayer/first-person observer depth texture=] as follows:
+      <dl class="switch">
+        <dt> If the |session| was created with "[=feature descriptor/secondary-views=]" enabled
+          <dd> Let [=XRProjectionLayer/first-person observer depth texture=] be the result of [=allocate the depth texture for the first-person observer view=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/depth}}, |init|'s {{XRProjectionLayerInit/stencil}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
+        <dt> Otherwise
+          <dd> Let [=XRProjectionLayer/first-person observer depth texture=] be <code>null</code>.
+      </dl>
   1. Allocate and initialize resources compatible with |session|'s [=/XR device=], including GPU accessible memory buffers, as required to support the compositing of |layer|.
   1. If |layer|’s resources were unable to be created for any reason, throw an {{OperationError}} and abort these steps.
   1. Return |layer|.
@@ -1317,28 +1371,38 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
         <dd> Let |subimage| be a [=new=] {{XRWebGLSubImage}} in the [=relevant realm=] of [=this=].
         <dd> Let |subimage|'s {{XRSubImage/viewport}} be a [=new=] {{XRViewport}} in the [=relevant realm=] of [=this=].
     </dl>
-  1. let |frame| be |view|'s {{frame}}.
+  1. Let |frame| be |view|'s {{frame}}.
   1. Let |session| be [=this=] [=XRWebGLBinding/session=].
   1. If [=validate the state of the XRWebGLSubImage creation function=] with |layer| and |frame| is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
-  1. Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=].
+  1. Initialize |index| as follows:
+    <dl class="switch">
+      <dt class="switch">If |view| is the [=first-person observer view=] from |session|'s [=list of views=]
+        <dd>Let |index| be <code>0</code>.
+      <dt> Otherwise
+        <dd>Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=] excluding the [=first-person observer view=].
+    </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} as follows:
     <dl class="switch">
-      <dt class="switch">If the |layer| was created with a textureType of {{"texture-array"}}
+      <dt class="switch">If |view| is the [=first-person observer view=] from |session|'s [=list of views=]
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the [=XRProjectionLayer/first-person observer color texture=].
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
+      <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
       <dt> Otherwise
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
-      </dl>
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
     </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} as follows:
     <dl class="switch">
-      <dt class="switch">If the |layer|'s [=depthStencilTextures=] is an empty array.
+      <dt class="switch">If |view| is the [=first-person observer view=] from |session|'s [=list of views=]
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the [=XRProjectionLayer/first-person observer depth texture=].
+      <dt>Else if the |layer|'s [=depthStencilTextures=] is an empty array.
         <dd> Continue to the next entry.
       <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
       <dt> Otherwise
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.
-      </dl>
     </dl>
   1. Set |subimage|'s {{XRWebGLSubImage/textureWidth}} to the pixel width of |subimage|'s {{XRWebGLSubImage/colorTexture}}.
   1. Set |subimage|'s {{XRWebGLSubImage/textureHeight}} to the pixel height of |subimage|'s {{XRWebGLSubImage/colorTexture}}.

--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -887,7 +887,7 @@ an internal <dfn>depthStencilTextures</dfn> which is an |array| of {{WebGLTextur
 
 Each {{XRProjectionLayer}} created through {{XRWebGLBinding}} has an internal <dfn for="XRProjectionLayer">colorTextures for secondary views</dfn>
 array which is an |array| of {{WebGLTexture|WebGLTextures}} for color textures and an internal <dfn for="XRProjectionLayer">depthStencilTextures for secondary views</dfn>
-which is an |array| of {{WebGLTexture|WebGLTextures}}</dfn> for depth/stencil textures that are used to render the [=secondary view|secondary views=].
+array which is an |array| of {{WebGLTexture|WebGLTextures}}</dfn> for depth/stencil textures that are used to render the [=secondary view|secondary views=].
 
 <div class="algorithm" data-algorithm="construct-webgl-layer">
 
@@ -952,6 +952,7 @@ To <dfn>allocate color textures for projection layers</dfn> using an {{XRProject
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"mono"}} or {{XRLayerLayout/"default"}}:
         <dl class="switch">
         <dt> If |textureType| is {{"texture-array"}}:
+          <dd> If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=] excluding the [=secondary view|secondary views=], throw an {{NotSupportedError}} and abort these steps.
           <dd> Initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with |numViews| layers using |context|, |alpha|, |width| and |height|.
           <dd> Return |array| and abort these steps.
         <dt> Otherwise
@@ -1016,10 +1017,10 @@ To <dfn>allocate the color textures for the secondary views</dfn> using an {{XRP
     1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
     1. Initialize |texture| as follows:
          <dl class="switch">
-          <dt>If |textureType| is {{"texture-array"}}:
-            <dd>Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with |context|, |alpha|, |width| and |height|.
-          <dt>Otherwise
-            <dd>Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context|, |alpha|, |width| and |height|.
+          <dt> If |textureType| is {{"texture-array"}}:
+            <dd> Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with |context|, |alpha|, |width| and |height|.
+          <dt> Otherwise
+            <dd> Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context|, |alpha|, |width| and |height|.
          </dl>
     1. Append |texture| to |array|.
   1. Return |array| and abort these steps.
@@ -1041,10 +1042,10 @@ To <dfn>allocate the depth textures for the secondary views</dfn> using an {{XRP
     1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
     1. Initialize |texture| as follows:
          <dl class="switch">
-          <dt>If |textureType| is {{"texture-array"}}:
-            <dd>Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with |context|, |stencil|, |width| and |height|.
-          <dt>Otherwise
-            <dd>Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context|, |stencil|, |width| and |height|.
+          <dt> If |textureType| is {{"texture-array"}}:
+            <dd> Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with |context|, |stencil|, |width| and |height|.
+          <dt> Otherwise
+            <dd> Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context|, |stencil|, |width| and |height|.
          </dl>
     1. Append |texture| to |array|.
   1. Return |array| and abort these steps.
@@ -1317,11 +1318,11 @@ To <dfn>initialize the viewport</dfn> of an {{XRViewport}} |viewport| with a {{W
   1. Update |viewport| as follows:
     <dl class="switch">
       <dt class="switch">If |layout| is {{XRLayerLayout/"stereo-left-right"}}:
-        <dd>Set |viewport|'s {{XRViewport/x}} to the pixel width of |texture| multiplied by |offset| and divided by |num|.
-        <dd>Set |viewport|'s {{XRViewport/width}} to half the pixel width of |subimage|'s |texture| divided by |num|.
+        <dd> Set |viewport|'s {{XRViewport/x}} to the pixel width of |texture| multiplied by |offset| and divided by |num|.
+        <dd> Set |viewport|'s {{XRViewport/width}} to half the pixel width of |subimage|'s |texture| divided by |num|.
       <dt class="switch">Else if |layout| is {{XRLayerLayout/"stereo-top-bottom"}}:
-        <dd>Set |viewport|'s {{XRViewport/y}} to the pixel height of |texture| multiplied by |offset| and divided by |num|.
-        <dd>Set |viewport|'s {{XRViewport/height}} to the pixel height of |subimage|'s |texture| divided by |num|.
+        <dd> Set |viewport|'s {{XRViewport/y}} to the pixel height of |texture| multiplied by |offset| and divided by |num|.
+        <dd> Set |viewport|'s {{XRViewport/height}} to the pixel height of |subimage|'s |texture| divided by |num|.
     </dl>
 
 </div>
@@ -1383,44 +1384,44 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
 
   1. Initialize |subimage| as follows:
     <dl class="switch">
-      <dt>If {{XRWebGLBinding/getViewSubImage()}} was called previously with the same |binding|, |layer| and |view|, the user agent MAY:
-        <dd>Let |subimage| be the same {{XRWebGLSubImage}} object as returned by an earlier call with the same arguments.
-      <dt>Otherwise
-        <dd>Let |subimage| be a [=new=] {{XRWebGLSubImage}} in the [=relevant realm=] of [=this=].
-        <dd>Let |subimage|'s {{XRSubImage/viewport}} be a [=new=] {{XRViewport}} in the [=relevant realm=] of [=this=].
+      <dt> If {{XRWebGLBinding/getViewSubImage()}} was called previously with the same |binding|, |layer| and |view|, the user agent MAY:
+        <dd> Let |subimage| be the same {{XRWebGLSubImage}} object as returned by an earlier call with the same arguments.
+      <dt> Otherwise
+        <dd> Let |subimage| be a [=new=] {{XRWebGLSubImage}} in the [=relevant realm=] of [=this=].
+        <dd> Let |subimage|'s {{XRSubImage/viewport}} be a [=new=] {{XRViewport}} in the [=relevant realm=] of [=this=].
     </dl>
   1. Let |frame| be |view|'s {{frame}}.
   1. Let |session| be [=this=] [=XRWebGLBinding/session=].
   1. If [=validate the state of the XRWebGLSubImage creation function=] with |layer| and |frame| is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
   1. Initialize |index| as follows:
     <dl class="switch">
-      <dt>If |view| is a [=secondary view=] from |session|'s [=list of views=]
-        <dd>Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=] excluding the [=primary view|primary views=].
+      <dt> If |view| is a [=secondary view=] from |session|'s [=list of views=]
+        <dd> Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=] excluding the [=primary view|primary views=].
       <dt> Otherwise
-        <dd>Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=] excluding the [=secondary view|secondary views=].
+        <dd> Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=] excluding the [=secondary view|secondary views=].
     </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} as follows:
     <dl class="switch">
-      <dt>If |view| is a [=secondary view=] from |session|'s [=list of views=]
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=XRProjectionLayer/colorTextures for secondary views=].
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
+      <dt> If |view| is a [=secondary view=] from |session|'s [=list of views=]
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=XRProjectionLayer/colorTextures for secondary views=].
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
       <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
       <dt> Otherwise
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
     </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} as follows:
     <dl class="switch">
-      <dt>If the |layer|'s [=depthStencilTextures=] is an empty array.
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with <code>null</code>.
-      <dt>Else if |view| is a [=secondary view=] from |session|'s [=list of views=]
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=XRProjectionLayer/depthStencilTextures for secondary views=].
+      <dt> If the |layer|'s [=depthStencilTextures=] is an empty array.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with <code>null</code>.
+      <dt> Else if |view| is a [=secondary view=] from |session|'s [=list of views=]
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=XRProjectionLayer/depthStencilTextures for secondary views=].
       <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
       <dt> Otherwise
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.
     </dl>
   1. Set |subimage|'s {{XRWebGLSubImage/textureWidth}} to the pixel width of |subimage|'s {{XRWebGLSubImage/colorTexture}}.
   1. Set |subimage|'s {{XRWebGLSubImage/textureHeight}} to the pixel height of |subimage|'s {{XRWebGLSubImage/colorTexture}}.

--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -47,9 +47,9 @@ spec: webxr-1;
     type: dfn; text: updateRenderState; for: XRSession
     type: dfn; text: session; for: XRWebGLLayer
     type: dfn; text: layers; for: XRRenderStateInit
-spec: webxr-ar-module-1;
-    type: dfn; text: first-person observer view
-    type: dfn; text: secondary-views
+    type: dfn; text: secondary-views; for: secondary view
+    type: dfn; text: primary view
+    type: dfn; text: secondary view
 spec: html;
     type: dfn; text: check the usability of the image argument
     type: dfn; text: request the xr permission
@@ -398,10 +398,6 @@ The <dfn attribute for="XRProjectionLayer">ignoreDepthValues</dfn> attribute, if
 [=XR Compositor=] MUST NOT make use of values in the depth buffer attachment when rendering. When the attribute
 is <code>false</code> it indicates that the content of the depth buffer attachment will be used by the
 [=XR Compositor=] and is expected to be representative of the scene rendered into the layer.
-
-Each {{XRProjectionLayer}} has an internal {{WebGLTexture}} <dfn for="XRProjectionLayer">first-person observer color texture</dfn>
-and an internal {{WebGLTexture}} <dfn for="XRProjectionLayer">first-person observer depth texture</dfn> that are used to render
-the [=first-person observer view=].
 
 XRQuadLayer {#xrquadlayertype}
 -----------
@@ -886,8 +882,12 @@ NOTE: It is possible to create more than one {{XRWebGLBinding}}. Any layer creat
 be used with another instance of {{XRWebGLBinding}} as long as both were created with the same [=XRWebGLBinding/session=] and the same
 [=XRWebGLBinding/context=]. The lifetime of layers or instances of {{XRWebGLSubImage}} is not tied to the lifetime of the {{XRWebGLBinding}} that created them.
 
-Each {{XRCompositionLayer}} created through {{XRWebGLBinding}} has an internal <dfn>colorTextures</dfn> array which is an |array| of {{WebGLTexture}} for color textures and
-an internal <dfn>depthStencilTextures</dfn> which is an |array| of {{WebGLTexture}}</dfn> for depth/stencil textures.
+Each {{XRCompositionLayer}} created through {{XRWebGLBinding}} has an internal <dfn>colorTextures</dfn> array which is an |array| of {{WebGLTexture|WebGLTextures}} for color textures and
+an internal <dfn>depthStencilTextures</dfn> which is an |array| of {{WebGLTexture|WebGLTextures}}</dfn> for depth/stencil textures.
+
+Each {{XRProjectionLayer}} created through {{XRWebGLBinding}} has an internal <dfn for="XRProjectionLayer">colorTextures for secondary views</dfn>
+array which is an |array| of {{WebGLTexture|WebGLTextures}} for color textures and an internal <dfn for="XRProjectionLayer">depthStencilTextures for secondary views</dfn>
+which is an |array| of {{WebGLTexture|WebGLTextures}}</dfn> for depth/stencil textures that are used to render the [=secondary view|secondary views=].
 
 <div class="algorithm" data-algorithm="construct-webgl-layer">
 
@@ -929,8 +929,8 @@ To <dfn>determine the layout attribute</dfn> using an {{XRTextureType}} |texture
 <div class="algorithm" data-algorithm="determine the maximum scalefactor">
 
 To <dfn>determine the maximum scalefactor</dfn> using an {{XRSession}} |session|, an {{XRWebGLRenderingContext}} |context| and an {{XRLayerLayout}} |layout|, the user agent MUST run the following steps:
-  1. Let |largest width| be the largest width of the [=recommended WebGL texture resolution=] from the |session|'s [=list of views=] excluding the [=first-person observer view=].
-  1. Let |largest height| be the largest height of the [=recommended WebGL texture resolution=] from the |session|'s [=list of views=] excluding the [=first-person observer view=].
+  1. Let |largest width| be the largest width of the [=recommended WebGL texture resolution=] from the |session|'s [=list of views=] excluding the [=secondary view|secondary views=].
+  1. Let |largest height| be the largest height of the [=recommended WebGL texture resolution=] from the |session|'s [=list of views=] excluding the [=secondary view|secondary views=].
   1. If |layout| is {{XRLayerLayout/"stereo-left-right"}} layout, multiply |largest width| by <code>2</code>.
   1. If |layout| is {{XRLayerLayout/"stereo-top-bottom"}} layout, multiply |largest height| by <code>2</code>.
   1. Let |largest view dimension| be the largest of |largest width| or |largest height|.
@@ -945,8 +945,8 @@ To <dfn>allocate color textures for projection layers</dfn> using an {{XRProject
   1. Let |array| be a [=new=] array in the [=relevant realm=] of |context|.
   1. Let |context| be |layer|'s [=XRCompositionLayer/context=].
   1. Let |session| be |layer|'s [=XRCompositionLayer/session=].
-  1. Let |numViews| be the number of the |session|'s [=list of views=] excluding the [=first-person observer view=].
-  1. Let |view| be the first entry in the |session|'s [=list of views=] that is not a [=first-person observer view=].
+  1. Let |numViews| be the number of the |session|'s [=list of views=] excluding the [=secondary view|secondary views=].
+  1. Let |view| be the first entry in the |session|'s [=list of views=] that is not a [=secondary view|secondary views=].
   1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
   1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"mono"}} or {{XRLayerLayout/"default"}}:
@@ -956,14 +956,14 @@ To <dfn>allocate color textures for projection layers</dfn> using an {{XRProject
           <dd> Return |array| and abort these steps.
         <dt> Otherwise
           <dd> For each |view| in the |session|'s [=list of views=]:
-            1. If |view| is a [=first-person observer view=], continue.
+            1. If |view| is a [=secondary view=], continue.
             1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
             1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
             1. let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context|, |alpha|, |width| and |height|.
             1. Append |texture| to |array|.
           <dd> Return |array| and abort these steps.
         </dl>
-  1. If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=] excluding the [=first-person observer view=], throw an {{NotSupportedError}} and abort these steps.
+  1. If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=] excluding the [=secondary view|secondary views=], throw an {{NotSupportedError}} and abort these steps.
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |alpha|, |numViews| multiplied by |width| and |height|.
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |alpha|, |width| and |numViews| multiplied by |height|.
   1. return |array|.
@@ -979,8 +979,8 @@ To <dfn>allocate depth textures for projection layers</dfn> using an {{XRProject
   1. If |depth| and |stencil| are not set, return |array| and abort these steps.
   1. let |depthsupport| be true if |context| is a {{WebGL2RenderingContext}} or the {{WEBGL_depth_texture}} extension is enabled in |context|.
   1. If |depth| or |stencil| are set and |depthsupport| is false, throw {{TypeError}} and abort these steps.
-  1. let |numViews| be the number of the |session|'s [=list of views=] excluding the [=first-person observer view=].
-  1. Let |view| be the first entry in the |session|'s [=list of views=] that is not a [=first-person observer view=].
+  1. let |numViews| be the number of the |session|'s [=list of views=] excluding the [=secondary view|secondary views=].
+  1. Let |view| be the first entry in the |session|'s [=list of views=] that is not a [=secondary view=].
   1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
   1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"mono"}} or {{XRLayerLayout/"default"}}:
@@ -990,50 +990,68 @@ To <dfn>allocate depth textures for projection layers</dfn> using an {{XRProject
           <dd> Return |array| and abort these steps.
         <dt> Otherwise
           <dd> For each |view| in the |session|'s [=list of views=]:
-            1. If |view| is a [=first-person observer view=], continue.
+            1. If |view| is a [=secondary view=], continue.
             1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
             1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
             1. let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context|, |stencil|, |width| and |height|.
             1. Append |texture| to |array|.
           <dd> Return |array| and abort these steps.
         </dl>
-  1. If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=] excluding the [=first-person observer view=], throw an {{NotSupportedError}} and abort these steps.
+  1. If the session’s [=view|views=] in the [=list of views=] don't all have the same [=recommended WebGL texture resolution=] excluding the [=secondary view|secondary views=], throw an {{NotSupportedError}} and abort these steps.
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |stencil|, |numViews| multiplied by |width| and |height|.
   1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| , |stencil|, |width| and |numViews| multiplied by |height|.
   1. return |array|.
 
 </div>
 
-<div class="algorithm" data-algorithm="allocate color texture for the first-person observer view">
+<div class="algorithm" data-algorithm="allocate color textures for the secondary views">
 
-To <dfn>allocate the color texture for the first-person observer view</dfn> using an {{XRProjectionLayer}} |layer|, an {{XRTextureType}} |textureType|, a boolean |alpha| and a float |scaleFactor|, the user agent MUST run the following steps:
+To <dfn>allocate the color textures for the secondary views</dfn> using an {{XRProjectionLayer}} |layer|, an {{XRTextureType}} |textureType|, a boolean |alpha| and a float |scaleFactor|, the user agent MUST run the following steps:
   1. Let |context| be |layer|'s [=XRCompositionLayer/context=].
   1. Let |session| be |layer|'s [=XRCompositionLayer/session=].
-  1. Let |view| be the [=first-person observer view=] from |session|'s [=list of views=].
-  1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
-  1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
-  1. If |textureType| is {{XRTextureType/"texture-array"}}, return a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with <code>1</code> layer using |context|, |alpha|, |width| and |height|.
-  1. Return a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context|, |alpha|, |width| and |height|.
+  1. Let |array| be a [=new=] array in the [=relevant realm=] of |context|.
+  1. For each |view| in the |session|'s [=list of views=]:
+    1. If |view| is not a [=secondary view=], continue.
+    1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
+    1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
+    1. Initialize |texture| as follows:
+         <dl class="switch">
+          <dt>If |textureType| is {{"texture-array"}}:
+            <dd>Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with |context|, |alpha|, |width| and |height|.
+          <dt>Otherwise
+            <dd>Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context|, |alpha|, |width| and |height|.
+         </dl>
+    1. Append |texture| to |array|.
+  1. Return |array| and abort these steps.
 
 </div>
 
-<div class="algorithm" data-algorithm="allocate depth texture for the first-person observer view">
+<div class="algorithm" data-algorithm="allocate depth textures for the secondary views">
 
-To <dfn>allocate the depth texture for the first-person observer view</dfn> using an {{XRProjectionLayer}} |layer|, an {{XRTextureType}} |textureType|, a boolean |depth|, a boolean |stencil| and a float |scaleFactor|, the user agent MUST run the following steps:
+To <dfn>allocate the depth textures for the secondary views</dfn> using an {{XRProjectionLayer}} |layer|, an {{XRTextureType}} |textureType|, a boolean |depth|, a boolean |stencil| and a float |scaleFactor|, the user agent MUST run the following steps:
   1. Let |context| be |layer|'s [=XRCompositionLayer/context=].
   1. Let |session| be |layer|'s [=XRCompositionLayer/session=].
   1. If |depth| and |stencil| are not set, return <code>null</code> and abort these steps.
   1. let |depthsupport| be true if |context| is a {{WebGL2RenderingContext}} or the {{WEBGL_depth_texture}} extension is enabled in |context|.
   1. If |depth| or |stencil| are set and |depthsupport| is false, throw {{TypeError}} and abort these steps.
-  1. Let |view| be the [=first-person observer view=] from |session|'s [=list of views=].
-  1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
-  1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
-  1. If |textureType| is {{XRTextureType/"texture-array"}}, return a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with <code>1</code> layer using |context|, |stencil|, |width| and |height| and abort these steps.
-  1. Return a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture using |context|, |stencil|, |width| and |height|.
+  1. Let |array| be a [=new=] array in the [=relevant realm=] of |context|.
+  1. For each |view| in the |session|'s [=list of views=]:
+    1. If |view| is not a [=secondary view=], continue.
+    1. Let |width| be the width of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
+    1. Let |height| be the height of |view|'s [=recommended WebGL texture resolution=] multiplied by |scaleFactor|.
+    1. Initialize |texture| as follows:
+         <dl class="switch">
+          <dt>If |textureType| is {{"texture-array"}}:
+            <dd>Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D_ARRAY}} texture with |context|, |stencil|, |width| and |height|.
+          <dt>Otherwise
+            <dd>Let |texture| be a [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context|, |stencil|, |width| and |height|.
+         </dl>
+    1. Append |texture| to |array|.
+  1. Return |array| and abort these steps.
 
 </div>
 
-ISSUE: the scaleFactor needs to be recalculated for the first-person observer view.
+ISSUE: the scaleFactor needs to be recalculated for the secondary views.
 
 <div class="algorithm" data-algorithm="allocate color textures">
 
@@ -1086,8 +1104,8 @@ To <dfn>allocate depth textures</dfn> using an {{XRCompositionLayer}} |layer|, a
           <dd> Initialize |array| with 2 [=new=] instances of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a {{TEXTURE_2D}} texture with |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
         <dd> Return |array| and abort these steps.
         </dl>
-  1. If |layer|'s {{XRCompositionLayer/layout}}  is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| and |init|'s {{XRLayerInit/stencil}}, double of {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
-  1. If |layer|'s {{XRCompositionLayer/layout}}  is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and double of {{XRLayerInit/viewPixelHeight}} values.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-left-right}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| and |init|'s {{XRLayerInit/stencil}}, double of {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
+  1. If |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/stereo-top-bottom}}, initialize |array| with 1 [=new=] instance of {{WebGLTexture}} in the [=relevant realm=] of |context| created as a |textureType| texture using |context| and |init|'s {{XRLayerInit/stencil}}, {{XRLayerInit/viewPixelWidth}} and double of {{XRLayerInit/viewPixelHeight}} values.
   1. return |array|.
 
 </div>
@@ -1118,19 +1136,19 @@ When this method is invoked, the user agent MUST run the following steps:
   1. Initialize |layer|'s {{XRCompositionLayer/needsRedraw}} to <code>true</code>.
   1. let |layer|'s [=colorTextures=] be the result of [=allocate color textures for projection layers|allocating color textures for projection layers=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/alpha}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
   1. let |layer|'s [=depthStencilTextures=] be the result of [=allocate depth textures for projection layers|allocating depth textures for projection layers=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/depth}}, |init|'s {{XRProjectionLayerInit/stencil}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
-  1. Initialize the [=XRProjectionLayer/first-person observer color texture=] as follows:
+  1. Initialize the [=XRProjectionLayer/colortextures for secondary views=] as follows:
       <dl class="switch">
-        <dt> If the |session| was created with "[=feature descriptor/secondary-views=]" enabled
-          <dd> Let [=XRProjectionLayer/first-person observer color texture=] be the result of [=allocate the color texture for the first-person observer view=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/alpha}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
+        <dt> If the |session| was created with "[=secondary view/secondary-views=]" enabled
+          <dd> Let [=XRProjectionLayer/colortextures for secondary views=] be the result of [=allocate the color textures for the secondary views=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/alpha}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
         <dt> Otherwise
-          <dd> Let [=XRProjectionLayer/first-person observer color texture=] be <code>null</code>.
+          <dd> Let [=XRProjectionLayer/colortextures for secondary views=] be <code>null</code>.
       </dl>
-  1. Initialize the [=XRProjectionLayer/first-person observer depth texture=] as follows:
+  1. Initialize the [=XRProjectionLayer/depthstenciltextures for secondary views=] as follows:
       <dl class="switch">
-        <dt> If the |session| was created with "[=feature descriptor/secondary-views=]" enabled
-          <dd> Let [=XRProjectionLayer/first-person observer depth texture=] be the result of [=allocate the depth texture for the first-person observer view=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/depth}}, |init|'s {{XRProjectionLayerInit/stencil}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
+        <dt> If the |session| was created with "[=secondary view/secondary-views=]" enabled
+          <dd> Let [=XRProjectionLayer/depthstenciltextures for secondary views=] be the result of [=allocate the depth textures for the secondary views=] with |layer|, |textureType|, |init|'s {{XRProjectionLayerInit/depth}}, |init|'s {{XRProjectionLayerInit/stencil}} and |init|'s {{XRProjectionLayerInit/scaleFactor}}.
         <dt> Otherwise
-          <dd> Let [=XRProjectionLayer/first-person observer depth texture=] be <code>null</code>.
+          <dd> Let [=XRProjectionLayer/depthstenciltextures for secondary views=] be <code>null</code>.
       </dl>
   1. Allocate and initialize resources compatible with |session|'s [=/XR device=], including GPU accessible memory buffers, as required to support the compositing of |layer|.
   1. If |layer|’s resources were unable to be created for any reason, throw an {{OperationError}} and abort these steps.
@@ -1365,44 +1383,44 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
 
   1. Initialize |subimage| as follows:
     <dl class="switch">
-      <dt> If {{XRWebGLBinding/getViewSubImage()}} was called previously with the same |binding|, |layer| and |view|, the user agent MAY:
-        <dd> Let |subimage| be the same {{XRWebGLSubImage}} object as returned by an earlier call with the same arguments.
-      <dt> Otherwise
-        <dd> Let |subimage| be a [=new=] {{XRWebGLSubImage}} in the [=relevant realm=] of [=this=].
-        <dd> Let |subimage|'s {{XRSubImage/viewport}} be a [=new=] {{XRViewport}} in the [=relevant realm=] of [=this=].
+      <dt>If {{XRWebGLBinding/getViewSubImage()}} was called previously with the same |binding|, |layer| and |view|, the user agent MAY:
+        <dd>Let |subimage| be the same {{XRWebGLSubImage}} object as returned by an earlier call with the same arguments.
+      <dt>Otherwise
+        <dd>Let |subimage| be a [=new=] {{XRWebGLSubImage}} in the [=relevant realm=] of [=this=].
+        <dd>Let |subimage|'s {{XRSubImage/viewport}} be a [=new=] {{XRViewport}} in the [=relevant realm=] of [=this=].
     </dl>
   1. Let |frame| be |view|'s {{frame}}.
   1. Let |session| be [=this=] [=XRWebGLBinding/session=].
   1. If [=validate the state of the XRWebGLSubImage creation function=] with |layer| and |frame| is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
   1. Initialize |index| as follows:
     <dl class="switch">
-      <dt class="switch">If |view| is the [=first-person observer view=] from |session|'s [=list of views=]
-        <dd>Let |index| be <code>0</code>.
+      <dt>If |view| is a [=secondary view=] from |session|'s [=list of views=]
+        <dd>Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=] excluding the [=primary view|primary views=].
       <dt> Otherwise
-        <dd>Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=] excluding the [=first-person observer view=].
+        <dd>Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=] excluding the [=secondary view|secondary views=].
     </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} as follows:
     <dl class="switch">
-      <dt class="switch">If |view| is the [=first-person observer view=] from |session|'s [=list of views=]
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the [=XRProjectionLayer/first-person observer color texture=].
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
+      <dt>If |view| is a [=secondary view=] from |session|'s [=list of views=]
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=XRProjectionLayer/colorTextures for secondary views=].
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
       <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
       <dt> Otherwise
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
     </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} as follows:
     <dl class="switch">
-      <dt class="switch">If |view| is the [=first-person observer view=] from |session|'s [=list of views=]
-        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the [=XRProjectionLayer/first-person observer depth texture=].
-      <dt>Else if the |layer|'s [=depthStencilTextures=] is an empty array.
-        <dd> Continue to the next entry.
+      <dt>If the |layer|'s [=depthStencilTextures=] is an empty array.
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with <code>null</code>.
+      <dt>Else if |view| is a [=secondary view=] from |session|'s [=list of views=]
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=XRProjectionLayer/depthStencilTextures for secondary views=].
       <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
       <dt> Otherwise
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.
+        <dd>Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.
     </dl>
   1. Set |subimage|'s {{XRWebGLSubImage/textureWidth}} to the pixel width of |subimage|'s {{XRWebGLSubImage/colorTexture}}.
   1. Set |subimage|'s {{XRWebGLSubImage/textureHeight}} to the pixel height of |subimage|'s {{XRWebGLSubImage/colorTexture}}.

--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -31,7 +31,7 @@ spec: webxr-1;
     type: dfn; text: apply the pending render state
     type: dfn; text: viewer reference space
     type: dfn; text: xr animation frame
-    type: dfn; text: immersive xr device; for: XRSystem
+    type: dfn; text: immersive xr device
     type: dfn; text: list of views; for: XRSession/viewer reference space
     type: dfn; text: list of viewports
     type: dfn; text: opaque framebuffer
@@ -1348,14 +1348,14 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
 
 </div>
 
-When an {{XRLayer}} is a member of the {{XRRenderState/layers}} array, it MUST be presented to the [=XRSystem/immersive XR device=] immediately after
+When an {{XRLayer}} is a member of the {{XRRenderState/layers}} array, it MUST be presented to the [=immersive XR device=] immediately after
 an [=XR animation frame=] completes, but only if at least one of the following has occurred since the previous [=XR animation frame=]:
 
   - The {{XRLayer}} was added to {{XRRenderState/layers}} since the previous [=XR animation frame=].
   - {{XRLayer}} is an {{XRWebGLLayer}} and {{clear}}, {{drawArrays}}, {{drawElements}}, or any other rendering operation which similarly affects the framebuffer's color values has been called while the [=opaque framebuffer=] is the currently bound framebuffer of the {{WebGLRenderingContext}} associated with the {{XRWebGLLayer}}.
   - {{XRLayer}} is an {{XRCompositionLayer}} and {{XRWebGLBinding/getSubImage()}} or {{XRWebGLBinding/getViewSubImage()}} was called and any rendering operation has been called that affects the color value of the {{XRWebGLSubImage/colorTexture}} texture.
 
-Before the [=opaque framebuffer=] or {{XRWebGLSubImage/colorTexture}} texture are presented to the [=XRSystem/immersive XR device=] the user agent MUST ensure that all rendering operations have been flushed.
+Before the [=opaque framebuffer=] or {{XRWebGLSubImage/colorTexture}} texture are presented to the [=immersive XR device=] the user agent MUST ensure that all rendering operations have been flushed.
 
 Video layer creation {#videolayer}
 ====================
@@ -1592,19 +1592,12 @@ XRCompositor changes {#xrcompositorchanges}
 The [=XR Compositor=] MUST be extended so all {{XRLayer}} instances from the {{XRRenderState/layers}} array are composited
 at the same time. All other requirements for [=XR Compositor|WebXR=] MUST continue to apply.
 
-If the [=XR Compositor=] is driving a monoscopic display and the rendered {{XRCompositionLayer}} has an {{XRLayerLayout}} of
-{{XRLayerLayout/"stereo-left-right"}}, only the left portion of the {{XRLayer}} is shown while the right portion is ignored.
-If the {{XRCompositionLayer}} was created through {{XRMediaBinding}} and the {{XRMediaLayerInit/"invertStereo"}} flag was set to
-<code>true</code>, the right portion of the {{XRLayer}} is shown while the left portion is ignored.
+If the [=XR Compositor=] is rendering to a [=view=] with an {{XREye}} of {{XREye/"none"}} and drawing an {{XRCompositionLayer}} which is NOT an
+{{XRProjectionLayer}} and does NOT have a {{XRCompositionLayer/layout}} of {{XRLayerLayout/"mono"}}, the [=XR Compositor=] MUST render that layer
+as if the [=view=] had an {{XREye}} of {{XREye/"left"}}.
 
-If the [=XR Compositor=] is driving a monoscopic display and the rendered {{XRCompositionLayer}} has an {{XRLayerLayout}} of
-{{XRLayerLayout/"stereo-top-bottom"}}, only the top portion of the {{XRLayer}} is shown while the bottom portion is ignored.
-If the {{XRCompositionLayer}} was created through {{XRMediaBinding}} and the {{XRMediaLayerInit/"invertStereo"}} flag was set to
-<code>true</code>, the bottom portion of the {{XRLayer}} is shown while the top portion is ignored.
-
-If the [=XR Compositor=] is driving additional displays in addition to a monoscopic or stereoscopic one, it is up to the
-user agent how a {{XRCompositionLayer}} with an {{XRLayerLayout}} of {{XRLayerLayout/"stereo-left-right"}} or
-{{XRLayerLayout/"stereo-top-bottom"}} is shown to those additional displays.
+NOTE: This means that the side for the right eye of the layer is ignored. This enables authors to use the same assets for stereoscopic and
+monoscopic devices.
 
 XRView changes {#xrviewchanges}
 --------------


### PR DESCRIPTION
This change should provide all the logic to support first-person observer views.
I'm unsure how the scale factor applies to this view. Should I open up another issue?

Also, the spec currently requires that the view of the first-person observer is in the list. I wonder if we can work around this. Maybe file it as another issue?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/176.html" title="Last updated on Jul 2, 2020, 5:51 PM UTC (d3cabdf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/176/c1bfccf...cabanier:d3cabdf.html" title="Last updated on Jul 2, 2020, 5:51 PM UTC (d3cabdf)">Diff</a>