### PR TITLE
Add validation to getViewSubImage

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -41,6 +41,8 @@ spec: webxr-1;
     type: dfn; text: type; for: XRReferenceSpace
     type: dfn; text: session; for: XRSpace
     type: dfn; text: view
+    type: dfn; text: frame time; for: XRView
+    type: dfn; text: time; for: XRFrame
     type: dfn; text: XRLayer
     type: dfn; text: XRReferenceSpace
     type: dfn; text: type; for: XRReferenceSpace
@@ -1319,6 +1321,7 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
     </dl>
   1. let |frame| be |view|'s {{frame}}.
   1. Let |session| be [=this=] [=XRWebGLBinding/session=].
+  1. If |frame|'s [=XRFrame/time=] is not equal to |view|'s [=XRView/frame time=], throw an {{InvalidStateError}} and abort these steps.
   1. If [=validate the state of the XRWebGLSubImage creation function=] with |layer| and |frame| is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
   1. Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=].
   1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} as follows:


### PR DESCRIPTION
To be in line with the changes in https://github.com/immersive-web/webxr/pull/1093


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/179.html" title="Last updated on Jul 2, 2020, 3:31 AM UTC (bd81dcb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/179/c1bfccf...cabanier:bd81dcb.html" title="Last updated on Jul 2, 2020, 3:31 AM UTC (bd81dcb)">Diff</a>