### PR TITLE
Take view's active flag into account

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -50,6 +50,7 @@ spec: webxr-1;
     type: dfn; text: secondary-views; for: secondary view
     type: dfn; text: primary view
     type: dfn; text: secondary view
+    type: dfn; text: active; for: view
 spec: html;
     type: dfn; text: check the usability of the image argument
     type: dfn; text: request the xr permission
@@ -1393,6 +1394,7 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
   1. Let |frame| be |view|'s {{frame}}.
   1. Let |session| be [=this=] [=XRWebGLBinding/session=].
   1. If [=validate the state of the XRWebGLSubImage creation function=] with |layer| and |frame| is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
+  1. If |view|'s [=view/active=] flag is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
   1. Initialize |index| as follows:
     <dl class="switch">
       <dt> If |view| is a [=secondary view=] from |session|'s [=list of views=]


### PR DESCRIPTION
Make sure we pass a valid XRView to getViewSubImage.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/181.html" title="Last updated on Jul 9, 2020, 8:23 PM UTC (511b643)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/181/83c454f...cabanier:511b643.html" title="Last updated on Jul 9, 2020, 8:23 PM UTC (511b643)">Diff</a>