### PR TITLE
Fixed incorrect name for media layer creation

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -1473,12 +1473,12 @@ The {{XRMediaBinding}} object is used to create layers that display the content 
 interface XRMediaBinding {
   constructor(XRSession session);
 
-  XRQuadLayer createQuadVideoLayer(HTMLVideoElement video,
-                                   optional XRMediaLayerInit init = {});
-  XRCylinderLayer createCylinderVideoLayer(HTMLVideoElement video,
-                                           optional XRMediaLayerInit init = {});
-  XREquirectLayer createEquirectVideoLayer(HTMLVideoElement video,
-                                           optional XRMediaLayerInit init = {});
+  XRQuadLayer createQuadLayer(HTMLVideoElement video,
+                              optional XRMediaLayerInit init = {});
+  XRCylinderLayer createCylinderLayer(HTMLVideoElement video,
+                                      optional XRMediaLayerInit init = {});
+  XREquirectLayer createEquirectLayer(HTMLVideoElement video,
+                                      optional XRMediaLayerInit init = {});
 };
 
 </pre>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/186.html" title="Last updated on Jul 31, 2020, 11:21 PM UTC (6fa47ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/186/5493c6b...cabanier:6fa47ad.html" title="Last updated on Jul 31, 2020, 11:21 PM UTC (6fa47ad)">Diff</a>