### PR TITLE
Removed word from stereo layer definition

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -240,7 +240,7 @@ Layer types {#xrlayertypes}
 
 Mono and stereo layers {#monovsstereo}
 ----------------------
-A stereo layer MUST supply a different {{XRSubImage}} to render to for each view.
+A stereo layer MUST supply an {{XRSubImage}} to render to for each view.
 
 A mono layer MUST supply a single {{XRSubImage}} which is shown to each view.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/205.html" title="Last updated on Sep 15, 2020, 10:09 PM UTC (eab1dce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/205/2d85cf8...cabanier:eab1dce.html" title="Last updated on Sep 15, 2020, 10:09 PM UTC (eab1dce)">Diff</a>