### PR TITLE
Only allow a single layer is `layers` is not requested.

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -1664,6 +1664,7 @@ This module replaces the steps given by "[=update the pending layers state=]" fr
     1. If |session|'s [=pending render state=] is <code>null</code>, set it to a copy of |activeState|.
     1. Set |session|'s [=pending render state=]'s {{XRRenderState/layers}} to <code>null</code>.
   1. If |newState|'s {{XRRenderStateInit/layers}} is set:
+    1. If |session| was not created with "[=feature descriptor/layers=]" enabled and |newState|'s {{XRRenderStateInit/layers}} contains more than <code>1</code> instance, throw a {{NotSupportedError}} and abort these steps.
     1. If |session|'s [=pending render state=] is <code>null</code>, set it to a copy of |activeState|.
     1. If |newState|'s {{XRRenderStateInit/layers}} contains duplicate instances, throw a {{TypeError}} and abort these steps.
     1. For each |layer| in |newState|'s {{XRRenderStateInit/layers}}:


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/206.html" title="Last updated on Sep 15, 2020, 10:28 PM UTC (9b48aef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/206/2d85cf8...cabanier:9b48aef.html" title="Last updated on Sep 15, 2020, 10:28 PM UTC (9b48aef)">Diff</a>