### PR TITLE
Disallow deletetexture on an opaque texture

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -81,9 +81,11 @@ spec: WebGL; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/1.0/
     type: interface; text: WebGLRenderingContext; url: WebGLRenderingContext
     type: interface; text: WebGLRenderingContextBase; url: WebGLRenderingContextBase
     type: interface; text: GLenum
+    type: typedef; text: INVALID_OPERATION; url: WebGLRenderingContextBase
     type: typedef; text: TEXTURE_2D; url: 5.14
     type: typedef; text: TEXTURE_CUBE_MAP; url: 5.14
     type: method; text: clear; url: 5.14.11
+    type: method; text: deleteTexture;  url: 5.14.8
     type: method; text: drawArrays; url: 5.14.11
     type: method; text: drawElements; url: 5.14.11
     type: dfn; text: WebGL viewport; url:#5.14.4
@@ -724,6 +726,7 @@ An [=opaque texture=] functions identically to a standard {{WebGLTexture}} with 
 - The [=XR Compositor=] MUST assume that the [=opaque texture=] for the color attachment contains colors with premultiplied alpha.
 - At the end of the {{XRSession/requestAnimationFrame()}} callback the texture MUST be unbounded and detached from all {{WebGLShader}} objects.
 - An [=opaque texture=] MUST behave as though it was allocated with [=texStorage2D=] or [=texStorage3D=], as appropriate, even when using a WebGL 1.0 context.
+- A call to {{deleteTexture}} with an [=opaque texture=] MUST generate an {{INVALID_OPERATION}} error.
 
 NOTE: the [=opaque texture|opaque textures=] are allocated when the layer is contructed using the
 [=allocate color textures=] and [=allocate depth textures=] algoritms. The side effect of this pre-allocation is that calling


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/211.html" title="Last updated on Sep 25, 2020, 11:53 AM UTC (a8943ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/211/5818d5d...cabanier:a8943ee.html" title="Last updated on Sep 25, 2020, 11:53 AM UTC (a8943ee)">Diff</a>