### PR TITLE
Added alt descriptions to images

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -436,7 +436,7 @@ XRProjectionLayer {#xrprojectionlayertype}
 An {{XRProjectionLayer}} is a layer that fills the entire view of the observer.
 Projection layers should be refreshed close to the device's native frame rate.
 
-<img src="images/projection-layer.jpg" style="width:50%; border-style: ridge;"/>
+<img alt="representation of a projection layer" src="images/projection-layer.jpg" style="width:50%; border-style: ridge;"/>
 
 <pre class="idl">
 [Exposed=Window] interface XRProjectionLayer : XRCompositionLayer {
@@ -457,7 +457,7 @@ Only the front of the layer MUST be visible; the back face MUST not be drawn by 
 A XRQuadLayer has no thicknes. It is a two-dimensional object positioned and oriented in 3D space. The position
 of a quad refers to the center of the quad.
 
-<img src="images/quad-layer.jpg" style="width:50%; border-style: ridge;"/>
+<img alt="representation of a quad layer" src="images/quad-layer.jpg" style="width:50%; border-style: ridge;"/>
 
 <pre class="idl">
 [Exposed=Window] interface XRQuadLayer : XRCompositionLayer {
@@ -503,7 +503,7 @@ XRCylinderLayer {#xrcylinderayertype}
 An {{XRCylinderLayer}} renders a layer that takes up a curved rectangular space in the virtual environment.
 Only the front of the layer MUST be visible; the back face MUST not be drawn by the [=XR Compositor=].
 
-<img src="images/cylinder-layer.png" style="width:50%; border-style: ridge;"/>
+<img alt="representation of a cylinder layer" src="images/cylinder-layer.png" style="width:50%; border-style: ridge;"/>
 
 A XRCylinderLayer has no thicknes. It is a two-dimensional object positioned and oriented in 3D space. The position
 of the cylinder refers to the center of the quad.
@@ -534,7 +534,7 @@ It grows symmetrically around the 0 angle.
 
 The <dfn attribute for="XRCylinderLayer">aspectRatio</dfn> attribute controls the ratio of the visible cylinder section.
 
-<img src="images/cylinder_layer_params.png" style="width:80%"/>
+<img alt="description of the parameters of a cylinder layer"src="images/cylinder_layer_params.png" style="width:80%"/>
 
 <div class="algorithm" data-algorithm="initCylinderLayerAlgo">
 When <dfn lt="initialize a cylinder layer">initializing an {{XRCylinderLayer}} |layer| with an {{XRCylinderLayerInit}} |init|</dfn>, the user agent MUST run the following steps:
@@ -559,7 +559,7 @@ XREquirectLayer {#xrequirectlayertype}
 ---------------
 An {{XREquirectLayer}} renders a layer where the [=XR Compositor=] MUST map an equirectangular coded data onto the inside of a sphere.
 
-<img src="images/equirect-layer.png" style="width:50%; border-style: ridge;"/>
+<img alt="representation of an equirect layer" src="images/equirect-layer.png" style="width:50%; border-style: ridge;"/>
 
 ISSUE: this section needs clarification
 
@@ -595,7 +595,7 @@ a value higher than 2π will set it to 2π.
 Setting {{XREquirectLayer/upperVerticalAngle}} or {{XREquirectLayer/lowerVerticalAngle}} to a value less than -π/2 will set it
 to -π/2 and setting it to a value higher than π/2 will set it to π/2.
 
-<img src="images/equirect.png" style="width:50%"/>
+<img alt="description of the parameters of an equirect layer" src="images/equirect.png" style="width:50%"/>
 
 When assigning an {{XRSpace}} to the {{XREquirectLayer/space}} attribute, first run the following steps.
 
@@ -632,7 +632,7 @@ XRCubeLayer {#xcubelayertype}
 -----------
 A {{XRCubeLayer}} renders a layer where the [=XR Compositor=] renders directly from a cubemap.
 
-<img src="images/cube-layer.jpg" style="width:50%; border-style: ridge;"/>
+<img alt="representation of a cube layer" src="images/cube-layer.jpg" style="width:50%; border-style: ridge;"/>
 
 ISSUE: this section needs clarification
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/230.html" title="Last updated on Dec 1, 2020, 5:47 PM UTC (a67c321)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/230/ed09308...cabanier:a67c321.html" title="Last updated on Dec 1, 2020, 5:47 PM UTC (a67c321)">Diff</a>