### PR TITLE
Rename textureLayers to textureArrayLength

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -442,7 +442,7 @@ Projection layers should be refreshed close to the device's native frame rate.
 [Exposed=Window] interface XRProjectionLayer : XRCompositionLayer {
   readonly attribute unsigned long textureWidth;
   readonly attribute unsigned long textureHeight;
-  readonly attribute unsigned long textureLayers;
+  readonly attribute unsigned long textureArrayLength;
 
   readonly attribute boolean ignoreDepthValues;
 };
@@ -454,7 +454,7 @@ the [=colorTextures=] textures of this layer.
 The <dfn attribute for="XRProjectionLayer">textureHeight</dfn> attribute returns the height in pixels of
 the [=colorTextures=] textures of this layer.
 
-The <dfn attribute for="XRProjectionLayer">textureLayers</dfn> attribute returns the number of layers of
+The <dfn attribute for="XRProjectionLayer">textureArrayLength</dfn> attribute returns the number of layers of
 the [=colorTextures=] textures of this layer if the {{XRProjectionLayer}} was initialized with a
 {{XRProjectionLayerInit/textureType}} of {{"texture-array"}}. Otherwise it will return <code>1</code>.
 


### PR DESCRIPTION
Closes #224


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 17, 2021, 5:45 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcabanier%2Flayers%2F292ebfa71eaa526c3349af3ec7bc3a6dc2270d77%2Fwebxrlayers-1.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20immersive-web/layers%23242.)._
</details>
