### PR TITLE
Add support to return the number of created mip levels

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -319,6 +319,7 @@ XRCompositionLayer defines a set of common attributes and behaviors across certa
   attribute boolean blendTextureSourceAlpha;
   attribute boolean? chromaticAberrationCorrection;
   attribute float? fixedFoveation;
+  readonly attribute unsigned long mipLevels;
 
   readonly attribute boolean needsRedraw;
 
@@ -345,6 +346,12 @@ The <dfn attribute for="XRCompositionLayer">needsRedraw</dfn> attribute signals 
 rerendered in the next [=XR animation frame=]. It MAY be set when [=the underlying resources of a layer are lost=] or
 when the [=XR Compositor=] can no longer reproject the layer. Failing to redraw the content in the next [=XR animation frame=]
 might cause flickering or other side effects.
+
+The <dfn attribute for="XRCompositionLayer">mipLevels</dfn> attribute returns the depth of the mip chain. This MUST be equal
+or smaller than the value requested in {{XRLayerInit/mipLevels}}.
+
+NOTE: some platforms don't support mip levels. Authors should query {{XRCompositionLayer/mipLevels}} to determine if they can
+target a certain mip level and not rely on the value they passed in {{XRLayerInit/mipLevels}}.
 
 <div class="algorithm" data-algorithm="redrawLayerAlgo">
 When <dfn>the underlying resources of a layer are lost</dfn> for an {{XRCompositionLayer}} |layer|,
@@ -950,6 +957,8 @@ For WebGL2 contexts these additional formats are supported:
  - {{DEPTH24_STENCIL8}}
 
 The <dfn dict-member for="XRLayerInit">mipLevels</dfn> attribute defines the desired number of mip levels in the color and texture data.
+If the user agent can't create the requested number, it can create less. Authors MUST query {{XRCompositionLayer/mipLevels}} to determine
+the actual number of mip levels.
 
 The <dfn dict-member for="XRLayerInit">viewPixelWidth</dfn> and <dfn dict-member for="XRLayerInit">viewPixelHeight</dfn> attributes define
 the rectangular dimensions of the {{XRCompositionLayer}}.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/245.html" title="Last updated on Jan 28, 2021, 9:15 AM UTC (d3a3c75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/245/5639438...cabanier:d3a3c75.html" title="Last updated on Jan 28, 2021, 9:15 AM UTC (d3a3c75)">Diff</a>