### PR TITLE
Fix for missing handling of side-by-side textures and a typo

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -1500,7 +1500,7 @@ To <dfn>initialize the viewport</dfn> of an {{XRViewport}} |viewport| with a [=o
     <dl class="switch">
       <dt class="switch">If |layout| is {{XRLayerLayout/"stereo-left-right"}}:
         <dd> Set |viewport|'s {{XRViewport/x}} to the pixel width of |texture| multiplied by |offset| and divided by |num|.
-        <dd> Set |viewport|'s {{XRViewport/width}} to half the pixel width of |subimage|'s |texture| divided by |num|.
+        <dd> Set |viewport|'s {{XRViewport/width}} to the pixel width of |subimage|'s |texture| divided by |num|.
       <dt class="switch">Else if |layout| is {{XRLayerLayout/"stereo-top-bottom"}}:
         <dd> Set |viewport|'s {{XRViewport/y}} to the pixel height of |texture| multiplied by |offset| and divided by |num|.
         <dd> Set |viewport|'s {{XRViewport/height}} to the pixel height of |subimage|'s |texture| divided by |num|.
@@ -1582,17 +1582,23 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
       <dt> Otherwise
         <dd> Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=] excluding the [=secondary view|secondary views=].
     </dl>
+  1. Let |layout| be |layer|'s {{XRCompositionLayer/layout}}.
+  1. Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
+  1. Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} as follows:
+    <dl class="switch">
+      <dt> If the |layer| was created with a textureType of {{"texture-array"}}:
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
+      <dt> Otherwise
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
+    </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} as follows:
     <dl class="switch">
       <dt> If |view| is a [=secondary view=] from |session|'s [=list of views=]
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=XRProjectionLayer/colorTextures for secondary views=].
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
-      <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
+      <dt> Else if the |layer| was created with a textureType of {{"texture-array"}} or if |layout| is {{XRLayerLayout/"stereo-left-right"}} or {{XRLayerLayout/"stereo-top-bottom"}}
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
       <dt> Otherwise
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
     </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} as follows:
     <dl class="switch">
@@ -1600,7 +1606,7 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with <code>null</code>.
       <dt> Else if |view| is a [=secondary view=] from |session|'s [=list of views=]
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=XRProjectionLayer/depthStencilTextures for secondary views=].
-      <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
+      <dt> Else if the |layer| was created with a textureType of {{"texture-array"}} or if |layout| is {{XRLayerLayout/"stereo-left-right"}} or {{XRLayerLayout/"stereo-top-bottom"}}
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
       <dt> Otherwise
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/251.html" title="Last updated on Feb 24, 2021, 6:42 PM UTC (6e5be2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/251/dd11428...cabanier:6e5be2e.html" title="Last updated on Feb 24, 2021, 6:42 PM UTC (6e5be2e)">Diff</a>