### PR TITLE
Some fixes in getSubImage and getViewSubImage

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -1455,9 +1455,9 @@ When this method is invoked, the user agent MUST run the following steps:
   1. Let |layer|'s [=depthStencilTextures=] be a [=new=] array in the [=relevant realm=] of this {{XRCubeLayer}}.
   1. If |init|'s {{XRLayerInit/depthFormat}} is set, initialize |layer|'s [=depthStencilTextures=] as follows:
     <dl class="switch">
-      <dt> If |context| is not a {{WebGL2RenderingContext}} and the {{WEBGL_depth_texture}} [=extension=] is not enabled in |context|.
+      <dt> If |context| is not a {{WebGL2RenderingContext}} and the {{WEBGL_depth_texture}} [=extension=] is not enabled in |context|
         <dd> Throw {{TypeError}} and abort these steps.
-      <dt> Else if |layout| is {{XRLayerLayout/"mono"}}:
+      <dt> Else if |layout| is {{XRLayerLayout/"mono"}}
         <dd> Initialize [=depthStencilTextures=] with 1 [=new=] instance of an [=opaque texture=] in the [=relevant realm=] of this {{XRCubeLayer}} created as a {{TEXTURE_CUBE_MAP}} texture with |context| and |init|'s {{XRLayerInit/depthFormat}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
       <dt> Otherwise
         <dd> Initialize [=depthStencilTextures=] with 2 [=new=] instances of an [=opaque texture=] in the [=relevant realm=] of this {{XRCubeLayer}} created as a {{TEXTURE_CUBE_MAP}} texture with |context| and |init|'s {{XRLayerInit/depthFormat}}, {{XRLayerInit/viewPixelWidth}} and {{XRLayerInit/viewPixelHeight}} values.
@@ -1498,10 +1498,10 @@ To <dfn>initialize the viewport</dfn> of an {{XRViewport}} |viewport| with a [=o
   1. Set |viewport|'s {{XRViewport/height}} to the pixelh eight of |texture|.
   1. Update |viewport| as follows:
     <dl class="switch">
-      <dt class="switch">If |layout| is {{XRLayerLayout/"stereo-left-right"}}:
+      <dt class="switch">If |layout| is {{XRLayerLayout/"stereo-left-right"}}
         <dd> Set |viewport|'s {{XRViewport/x}} to the pixel width of |texture| multiplied by |offset| and divided by |num|.
         <dd> Set |viewport|'s {{XRViewport/width}} to the pixel width of |subimage|'s |texture| divided by |num|.
-      <dt class="switch">Else if |layout| is {{XRLayerLayout/"stereo-top-bottom"}}:
+      <dt class="switch">Else if |layout| is {{XRLayerLayout/"stereo-top-bottom"}}
         <dd> Set |viewport|'s {{XRViewport/y}} to the pixel height of |texture| multiplied by |offset| and divided by |num|.
         <dd> Set |viewport|'s {{XRViewport/height}} to the pixel height of |subimage|'s |texture| divided by |num|.
     </dl>
@@ -1515,7 +1515,7 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
 
   1. Initialize |subimage| as follows:
     <dl class="switch">
-      <dt> If {{XRWebGLBinding/getSubImage()}} was called previously with the same |binding|, |layer| and |eye|, the user agent MAY:
+      <dt> If {{XRWebGLBinding/getSubImage()}} was called previously with the same |binding|, |layer| and |eye|, the user agent MAY
         <dd> Let |subimage| be the same {{XRWebGLSubImage}} object as returned by an earlier call with the same arguments.
       <dt> Otherwise
         <dd> Let |subimage| be a [=new=] {{XRWebGLSubImage}} in the [=relevant realm=] of [=this=].
@@ -1528,31 +1528,36 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
     1. If |eye| is {{XREye/"none"}}, throw a {{TypeError}} and abort these steps.
     1. If |eye| is {{XREye/"right"}}, set |index| to <code>1</code>.
   1. If [=validate the state of the XRWebGLSubImage creation function=] with |layer| and |frame| is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
-  1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} as follows:
+  1. Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} as follows:
     <dl class="switch">
       <dt class="switch">If the |layer| was created with a textureType of {{"texture-array"}}
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
       <dt> Otherwise
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
+      </dl>
+    </dl>
+  1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} as follows:
+    <dl class="switch">
+      <dt class="switch">If the |layer| was created with a textureType of {{"texture"}}
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
+      <dt> Otherwise
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
       </dl>
     </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} as follows:
     <dl class="switch">
-      <dt class="switch">If the |layer|'s [=depthStencilTextures=] is an empty array.
-        <dd> Continue to the next entry.
-      <dt> Else if the |layer| was created with a textureType of {{"texture-array"}}
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
-      <dt> Otherwise
+      <dt class="switch">If the |layer|'s [=depthStencilTextures=] is an empty array
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with <code>null</code>.
+      <dt> Else the |layer| was created with a textureType of {{"texture"}}
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.
+      <dt> Otherwise
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
       </dl>
   1. Set |subimage|'s {{XRWebGLSubImage/textureWidth}} to the pixel width of |subimage|'s {{XRWebGLSubImage/colorTexture}}.
   1. Set |subimage|'s {{XRWebGLSubImage/textureHeight}} to the pixel height of |subimage|'s {{XRWebGLSubImage/colorTexture}}.
-  1. Let |index| be <code>0</code>.
-  1. If |eye| is {{XREye/"right"}}, set |index| to <code>1</code>.
-  1. Let |num| be <code>1</code>.
-  1. If |eye| is not {{XREye/"none"}} and |layer|'s {{XRCompositionLayer/layout}} attribute is {{XRLayerLayout/"stereo-left-right"}} or {{XRLayerLayout/"stereo-top-bottom"}}, set |num| to <code>2</code>.
-  1. Run [=initialize the viewport=] on |subimage|'s {{XRSubImage/viewport}} with |subimage|'s {{XRWebGLSubImage/colorTexture}}, |layer|'s {{XRCompositionLayer/layout}}, |index| and |num|.
+  1. Let |viewsPerTexture| be <code>1</code>.
+  1. If |layer|'s {{XRCompositionLayer/layout}} attribute is {{XRLayerLayout/"stereo-left-right"}} or {{XRLayerLayout/"stereo-top-bottom"}}, set |viewsPerTexture| to <code>2</code>.
+  1. Run [=initialize the viewport=] on |subimage|'s {{XRSubImage/viewport}} with |subimage|'s {{XRWebGLSubImage/colorTexture}}, |layer|'s {{XRCompositionLayer/layout}}, |index| and |viewsPerTexture|.
   1. [=Queue a task=] to set {{XRCompositionLayer/needsRedraw}} to <code>false</code>.
   1. return |subimage|.
 
@@ -1565,7 +1570,7 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
 
   1. Initialize |subimage| as follows:
     <dl class="switch">
-      <dt> If {{XRWebGLBinding/getViewSubImage()}} was called previously with the same |binding|, |layer| and |view|, the user agent MAY:
+      <dt> If {{XRWebGLBinding/getViewSubImage()}} was called previously with the same |binding|, |layer| and |view|, the user agent MAY
         <dd> Let |subimage| be the same {{XRWebGLSubImage}} object as returned by an earlier call with the same arguments.
       <dt> Otherwise
         <dd> Let |subimage| be a [=new=] {{XRWebGLSubImage}} in the [=relevant realm=] of [=this=].
@@ -1582,34 +1587,32 @@ When this method is invoked on an {{XRWebGLBinding}} |binding|, it MUST run the 
       <dt> Otherwise
         <dd> Let |index| be the offset of |view|'s [=view=] in |session|'s [=list of views=] excluding the [=secondary view|secondary views=].
     </dl>
-  1. Let |layout| be |layer|'s {{XRCompositionLayer/layout}}.
-  1. Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
   1. Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} as follows:
     <dl class="switch">
       <dt> If the |layer| was created with a textureType of {{"texture-array"}}:
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with |index|.
       <dt> Otherwise
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} with <code>0</code>.
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/imageIndex}} to <code>0</code>.
     </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} as follows:
     <dl class="switch">
       <dt> If |view| is a [=secondary view=] from |session|'s [=list of views=]
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=XRProjectionLayer/colorTextures for secondary views=].
-      <dt> Else if the |layer| was created with a textureType of {{"texture-array"}} or if |layout| is {{XRLayerLayout/"stereo-left-right"}} or {{XRLayerLayout/"stereo-top-bottom"}}
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
-      <dt> Otherwise
+      <dt> Else if the |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"default"}} and the |layer| was created with a textureType of {{"texture"}}
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=colorTextures=] array.
+      <dt> Otherwise
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the first element of the |layer|'s [=colorTextures=] array.
     </dl>
   1. Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} as follows:
     <dl class="switch">
-      <dt> If the |layer|'s [=depthStencilTextures=] is an empty array.
+      <dt> If the |layer|'s [=depthStencilTextures=] is an empty array
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with <code>null</code>.
       <dt> Else if |view| is a [=secondary view=] from |session|'s [=list of views=]
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/colorTexture}} with the element at offset |index| of the |layer|'s [=XRProjectionLayer/depthStencilTextures for secondary views=].
-      <dt> Else if the |layer| was created with a textureType of {{"texture-array"}} or if |layout| is {{XRLayerLayout/"stereo-left-right"}} or {{XRLayerLayout/"stereo-top-bottom"}}
-        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
-      <dt> Otherwise
+      <dt> Else if the |layer|'s {{XRCompositionLayer/layout}} is {{XRLayerLayout/"default"}} and the |layer| was created with a textureType of {{"texture"}}
         <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the element at offset |index| of the |layer|'s [=depthStencilTextures=] array.
+      <dt> Otherwise
+        <dd> Initialize |subimage|'s {{XRWebGLSubImage/depthStencilTexture}} with the first element of |layer|'s [=depthStencilTextures=] array.
     </dl>
   1. Set |subimage|'s {{XRWebGLSubImage/textureWidth}} to the pixel width of |subimage|'s {{XRWebGLSubImage/colorTexture}}.
   1. Set |subimage|'s {{XRWebGLSubImage/textureHeight}} to the pixel height of |subimage|'s {{XRWebGLSubImage/colorTexture}}.


### PR DESCRIPTION
Some fixups that were found while we were creating the layers polyfill


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/253.html" title="Last updated on Mar 9, 2021, 7:57 PM UTC (fdaa640)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/253/4a763dd...cabanier:fdaa640.html" title="Last updated on Mar 9, 2021, 7:57 PM UTC (fdaa640)">Diff</a>