### PR TITLE
Minor fix for code example in explainer

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -223,7 +223,7 @@ function onXRFrame(time, xrFrame) {
   gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
 
   for (let view in xrViewerPose.views) {
-    let subImage = glLayerFactory.getViewSubImage(layer, view);
+    let subImage = xrGlBinding.getViewSubImage(layer, view);
     gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
       subImage.colorTexture, 0, subImage.imageIndex);
     gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT,


### PR DESCRIPTION
Just updating a variable name in code of one of the code samples in the explainer.

Best,
Jonathan

Note: Apparently I need a W3C account for the ipr check. You may want to replicate the change manually, since it's so simple.