### PR TITLE
Changed default state of media layer to transparent black

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -1850,7 +1850,7 @@ ISSUE: more clarification is needed on how the video is blitted to the layers.
 When an {{XRCompositionLayer}} |layer| with a {{HTMLVideoElement}} |media| needs to be rendered, the user agent
 MUST run the following steps:
   1. Let |usability| be the result of [=check the usability of the image argument|checking the usability of=] |media|.
-  1. If |usability| is <code>bad</code>, then fill the |layer| with opaque black and abort these steps.
+  1. If |usability| is <code>bad</code>, then fill the |layer| with transparent black and abort these steps.
   1. Fill the |layer| with the content of the |media| element.
 
 <!--


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/layers/pull/295.html" title="Last updated on Sep 21, 2022, 4:58 PM UTC (9c543d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/295/ffa90c3...cabanier:9c543d0.html" title="Last updated on Sep 21, 2022, 4:58 PM UTC (9c543d0)">Diff</a>