### PR TITLE
Fix target interfaces in definition of `redraw` event

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -2012,7 +2012,7 @@ Event Types {#event-types}
 
 The user agent MUST provide the following new events. Registration for and firing of the events must follow the usual behavior of DOM4 Events.
 
-The user agent MAY fire a <dfn event for="XRLayer">redraw</dfn> event on the {{XRLayer}} object when [=the underlying resources of a layer are lost=] or
+The user agent MAY fire a <dfn event for="XRQuadLayer,XRCylinderLayer,XREquirectLayer,XRCubeLayer">redraw</dfn> event on the {{XRLayer}} object when [=the underlying resources of a layer are lost=] or
 when the [=XR Compositor=] can no longer reproject the layer.
 
 The author SHOULD redraw the content of the layer at the next [=XR animation frame=]. The event must be of type {{XRLayerEvent}}.


### PR DESCRIPTION
The `redraw` event was defined with a `for="XRLayer"` attribute. That is not really correct, because the event can only fire at some of the `XRCompositionLayer` interfaces. This update adjusts the `for` attribute accordingly, making the definition consistent with the IDL definitions of the related `EventHandler` attributes.

(Via https://github.com/w3c/webref/issues/1216)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/layers/pull/306.html" title="Last updated on Apr 22, 2024, 12:21 PM UTC (05fc8ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/306/6a896da...tidoust:05fc8ae.html" title="Last updated on Apr 22, 2024, 12:21 PM UTC (05fc8ae)">Diff</a>