### PR TITLE
Fix several typedef links to WebGL 2.0 spec

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -119,14 +119,13 @@ spec: WebGL 2.0; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/
     type: typedef; text: TEXTURE_2D_ARRAY; url: 3.7
     type: dfn; text: texStorage2D; url: 3.7.6
     type: dfn; text: texStorage3D; url: 3.7.6
-    type: typedef; text: RGB8; url: #5.14
-    type: typedef; text: RGBA8; url: #5.14
-    type: typedef; text: RGBA16F; url: #5.14
-    type: typedef; text: SRGB8; url: #5.14
-    type: typedef; text: SRGB8_ALPHA8; url: #5.14
-    type: typedef; text: DEPTH_COMPONENT24; url: #5.14
-    type: typedef; text: DEPTH24_STENCIL8; url: #5.14
-    type: typedef; text: STENCIL_INDEX8; url: #5.14
+    type: typedef; text: RGB8; url: #3.7
+    type: typedef; text: RGBA8; url: #3.7
+    type: typedef; text: RGBA16F; url: #3.7
+    type: typedef; text: SRGB8; url: #3.7
+    type: typedef; text: SRGB8_ALPHA8; url: #3.7
+    type: typedef; text: DEPTH_COMPONENT24; url: #3.7
+    type: typedef; text: DEPTH24_STENCIL8; url: #3.7
 spec: WEBGL_depth_texture; urlPrefix: https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/
     type: typedef; text: WEBGL_depth_texture
     type: typedef; text: UNSIGNED_INT_24_8_WEBGL


### PR DESCRIPTION
Some typedef links to the WebGL 2.0 spec incorrectly linked to section [5.14 No MapBufferRange](https://registry.khronos.org/webgl/specs/latest/2.0/#5.14). Probably a copy and paste mistake from the links to the WebGL 1.0 spec. This PR updates them so they point to [3.7 The WebGL context](https://registry.khronos.org/webgl/specs/latest/2.0/#3.7) which lists the respective constants.

While testing the change I noticed that `STENCIL_INDEX8` wasn't used anywhere in the document at all, so I took the liberty to remove it as well in this PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mrxz/layers/pull/308.html" title="Last updated on May 10, 2024, 11:01 AM UTC (ba5374d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/308/64a37a4...mrxz:ba5374d.html" title="Last updated on May 10, 2024, 11:01 AM UTC (ba5374d)">Diff</a>