### PR TITLE
Update the pending layers state should link to the WebXR spec

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -54,6 +54,7 @@ spec: webxr;
     type: dfn; text: primary view
     type: dfn; text: secondary view
     type: dfn; text: active; for: view
+    type: dfn; text: update the pending layers state
     type: enum-value; text: local
 spec: html;
     type: dfn; text: check the usability of the image argument
@@ -2113,7 +2114,7 @@ updateRenderState changes {#updaterenderstatechanges}
 
 <div class="algorithm" data-algorithm="update-layers-state-for-layers">
 
-This module replaces the steps given by "[=update the pending layers state=]" from the WebXR specification. Instead when the user agent will
+This module replaces the steps given by "[=/update the pending layers state=]" from the WebXR specification. Instead when the user agent will
 <dfn dfn-for="layers">update the pending layers state</dfn> with {{XRSession}} |session| and {{XRRenderStateInit}} |newState|, it must run the following steps:
   1. If both |newState|'s {{XRRenderStateInit/baseLayer}} and |newState|'s {{XRRenderStateInit/layers}} are set, throw a {{NotSupportedError}} and abort these steps.
   1. Let |activeState| be |session|'s [=active render state=].


### PR DESCRIPTION
The module defines "update the pending layers state" too but when mentioning "This module replaces the steps" the link should point to the WebXR spec which is the one originally defining those steps.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/pull/317.html" title="Last updated on Nov 12, 2025, 12:56 PM UTC (ea488ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/317/734b8ed...ea488ae.html" title="Last updated on Nov 12, 2025, 12:56 PM UTC (ea488ae)">Diff</a>