### PR TITLE
Initialize the render state should link to the WebXR spec

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -55,6 +55,7 @@ spec: webxr;
     type: dfn; text: secondary view
     type: dfn; text: active; for: view
     type: dfn; text: update the pending layers state
+    type: dfn; text: initialize the render state
     type: enum-value; text: local
 spec: html;
     type: dfn; text: check the usability of the image argument
@@ -2102,7 +2103,7 @@ in order of its position in the array using [=source-over=] blending. Unless the
 NOTE: this means that each layer can potentially overwrite the previous layers whether or not the previous layers are virtually closer to the viewer.
 
 <div class="algorithm" data-algorithm="initialize-renderstate-for-layers">
-This module replaces the steps given by [=initialize the render state=]. Instead when an {{XRRenderState}} object |state|
+This module replaces the steps given by [=/initialize the render state=]. Instead when an {{XRRenderState}} object |state|
 is created for an {{XRSession}} |session|, the user agent MUST <dfn dfn-for="layers">initialize the render state</dfn> by running the following steps:
   1. Initialize |state| by running the original steps to [=initialize the render state=].
   1. Initialize |state|'s {{XRRenderState/layers}} with a [=new=] empty array in the [=relevant realm=] of |session|.


### PR DESCRIPTION
The module defines "initialize the render state" too but when mentioning "This module replaces the steps" the link should point to the WebXR spec which is the one originally defining those steps.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/pull/318.html" title="Last updated on Nov 12, 2025, 1:06 PM UTC (140f66d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/318/738d2d4...140f66d.html" title="Last updated on Nov 12, 2025, 1:06 PM UTC (140f66d)">Diff</a>