### PR TITLE
Allow UAs to enforce a max number of layers per render state

### DIFF
--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -2214,7 +2214,9 @@ This module extends and adds the following to the [=XRSession interface=]:
 };
 </pre>
 
-The <dfn attribute for="XRSession">maxRenderLayers</dfn> represents the maximum amount of layers that a session can render at a given time. It SHOULD be possible to create more than this number of layers at a given time, but they may not all be set via {{XRSession/updateRenderState()}} at once.
+The <dfn attribute for="XRSession">maxRenderLayers</dfn> represents the maximum number of layers that the compositor can handle, and thus the maximum size of any {{XRRenderStateInit}}'s {{XRRenderStateInit/layers}} array . It SHOULD be possible to create more than this number of layers at a given time.
+
+NOTE: This guidance is not intended to provide a limit on the number of layers allocatable by the user agent, as described in [[#xrlayerallocation | Allocation of layers]]. User Agents may allow e.g. for 20 layers to be created, while only allowing 10 at a time to be set via {{XRSession/updateRenderState()}}.
 
 Each {{XRSession}} has an internal [=WeakSet=] <dfn dfn-for="XRSession">bindings</dfn> that holds weak references to each {{XRWebGLBinding}} that was created with that session.
 

--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -2214,7 +2214,7 @@ This module extends and adds the following to the [=XRSession interface=]:
 };
 </pre>
 
-The <dfn attribute for="XRSession">maxRenderLayers</dfn> represents the maximum number of layers that the compositor can handle, and thus the maximum size of any {{XRRenderStateInit}}'s {{XRRenderStateInit/layers}} array . It SHOULD be possible to create more than this number of layers at a given time.
+The <dfn attribute for="XRSession">maxRenderLayers</dfn> represents the maximum number of layers that the compositor can handle, and thus the maximum size of any {{XRRenderStateInit}}'s {{XRRenderStateInit/layers}} array. It SHOULD be possible to create more than this number of layers at a given time.
 
 NOTE: This guidance is not intended to provide a limit on the number of layers allocatable by the user agent, as described in [[#xrlayerallocation | Allocation of layers]]. User Agents may allow e.g. for 20 layers to be created, while only allowing 10 at a time to be set via {{XRSession/updateRenderState()}}.
 

--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -2216,7 +2216,7 @@ This module extends and adds the following to the [=XRSession interface=]:
 
 The <dfn attribute for="XRSession">maxRenderLayers</dfn> represents the maximum number of layers that the compositor can handle, and thus the maximum size of any {{XRRenderStateInit}}'s {{XRRenderStateInit/layers}} array. It SHOULD be possible to create more than this number of layers at a given time.
 
-NOTE: This guidance is not intended to provide a limit on the number of layers allocatable by the user agent, as described in [[#xrlayerallocation | Allocation of layers]]. User Agents may allow e.g. for 20 layers to be created, while only allowing 10 at a time to be set via {{XRSession/updateRenderState()}}.
+NOTE: This guidance is not intended to provide a limit on the number of layers allocatable by the user agent, as described in [[#xrlayerallocation|Allocation of layers]]. User Agents may allow e.g. for 20 layers to be created, while only allowing 10 at a time to be set via {{XRSession/updateRenderState()}}.
 
 Each {{XRSession}} has an internal [=WeakSet=] <dfn dfn-for="XRSession">bindings</dfn> that holds weak references to each {{XRWebGLBinding}} that was created with that session.
 

--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -2154,6 +2154,7 @@ This module replaces the steps given by "[=/update the pending layers state=]" f
     1. Set |session|'s [=pending render state=]'s {{XRRenderState/layers}} to <code>null</code>.
   1. If |newState|'s {{XRRenderStateInit/layers}} is set:
     1. If |session| was not created with "[=feature descriptor/layers=]" enabled and |newState|'s {{XRRenderStateInit/layers}} contains more than <code>1</code> instance, throw a {{NotSupportedError}} and abort these steps.
+    1. If |newState|'s {{XRRenderState/layers}} contains more than {{XRSession/maxRenderLayers}} entries, throw a {{NotSupportedError}} and abort these steps.
     1. If |session|'s [=pending render state=] is <code>null</code>, set it to a copy of |activeState|.
     1. If |newState|'s {{XRRenderStateInit/layers}} contains duplicate instances, throw a {{TypeError}} and abort these steps.
     1. For each |layer| in |newState|'s {{XRRenderStateInit/layers}}:
@@ -2205,7 +2206,15 @@ with {{XRSession/renderState}} |state|, the user agent MUST run the following st
 
 XRSession changes {#xrsessionchanges}
 -----------------
-This module adds the following to the [=XRSession interface=]:
+This module extends and adds the following to the [=XRSession interface=]:
+
+<pre class="idl">
+[SecureContext, Exposed=Window] partial interface XRSession {
+  readonly attribute unsigned long maxRenderLayers;
+};
+</pre>
+
+The <dfn attribute for="XRSession">maxRenderLayers</dfn> represents the maximum amount of layers that a session can render at a given time. It SHOULD be possible to create more than this number of layers at a given time, but they may not all be set via {{XRSession/updateRenderState()}} at once.
 
 Each {{XRSession}} has an internal [=WeakSet=] <dfn dfn-for="XRSession">bindings</dfn> that holds weak references to each {{XRWebGLBinding}} that was created with that session.
 

--- a/webxrlayers-1.bs
+++ b/webxrlayers-1.bs
@@ -2214,9 +2214,9 @@ This module extends and adds the following to the [=XRSession interface=]:
 };
 </pre>
 
-The <dfn attribute for="XRSession">maxRenderLayers</dfn> represents the maximum number of layers that the compositor can handle, and thus the maximum size of any {{XRRenderStateInit}}'s {{XRRenderStateInit/layers}} array. It SHOULD be possible to create more than this number of layers at a given time.
+The <dfn attribute for="XRSession">maxRenderLayers</dfn> represents the maximum number of layers that the compositor MUST handle, and thus the maximum size of any {{XRRenderStateInit}}'s {{XRRenderStateInit/layers}} array. It SHOULD be possible to create more than this number of layers at a given time.
 
-NOTE: This guidance is not intended to provide a limit on the number of layers allocatable by the user agent, as described in [[#xrlayerallocation|Allocation of layers]]. User Agents may allow e.g. for 20 layers to be created, while only allowing 10 at a time to be set via {{XRSession/updateRenderState()}}.
+NOTE: This guidance is not intended to provide a limit on the number of layers allocatable by the user agent, as described in [[#xrlayerallocation|Allocation of layers]]. User Agents may allow e.g. for 20 layers to be created, while only allowing 10 at a time to be set via {{XRSession/updateRenderState()}}. It is also worth noting that because different layers may require a different amount of backend power or objects, user agents have some discretion in setting the `maxRenderLayers` value to ensure that at least that many layers can be rendered. However, user agents still need to reject whenever more layers are passed in, and cannot reject when less are passed in to updateRenderState.
 
 Each {{XRSession}} has an internal [=WeakSet=] <dfn dfn-for="XRSession">bindings</dfn> that holds weak references to each {{XRWebGLBinding}} that was created with that session.
 


### PR DESCRIPTION
Addes a `maxRenderLayers` attribute to XrSession and updates the `updateRenderState` algorithm to throw if a render state is provided with too many layers specified.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/pull/325.html" title="Last updated on Jan 21, 2026, 11:22 PM UTC (33ee74b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/layers/325/ae99c27...33ee74b.html" title="Last updated on Jan 21, 2026, 11:22 PM UTC (33ee74b)">Diff</a>